### PR TITLE
fix: handle errors on process terminate

### DIFF
--- a/src/logos_core/app_lifecycle.cpp
+++ b/src/logos_core/app_lifecycle.cpp
@@ -140,10 +140,12 @@ namespace AppLifecycle {
         // Terminate all plugin processes (Remote mode)
         if (!g_plugin_processes.isEmpty()) {
             qDebug() << "Terminating all plugin processes...";
+
             for (auto it = g_plugin_processes.begin(); it != g_plugin_processes.end(); ++it) {
                 QProcess* process = it.value();
                 QString pluginName = it.key();
                 
+                g_terminating_processes[pluginName] = process;
                 qDebug() << "Terminating plugin process:" << pluginName;
                 process->terminate();
                 
@@ -156,6 +158,8 @@ namespace AppLifecycle {
                 delete process;
             }
             g_plugin_processes.clear();
+            g_terminating_processes.clear();
+
         }
     #endif
         g_loaded_plugins.clear();

--- a/src/logos_core/core_context.cpp
+++ b/src/logos_core/core_context.cpp
@@ -29,6 +29,7 @@ QHash<QString, QString> g_known_plugins;
 // Hash to store plugin processes
 #ifndef Q_OS_IOS
 QHash<QString, QProcess*> g_plugin_processes;
+QHash<QString, QProcess*> g_terminating_processes;
 #endif
 
 // Hash to store LogosAPI instances for Local mode plugins

--- a/src/logos_core/logos_core_internal.h
+++ b/src/logos_core/logos_core_internal.h
@@ -35,6 +35,7 @@ extern QHash<QString, QString> g_known_plugins;
 // Global hash to store plugin processes
 #ifndef Q_OS_IOS
 extern QHash<QString, QProcess*> g_plugin_processes;
+extern QHash<QString, QProcess*> g_terminating_processes;
 #endif
 
 // Global hash to store LogosAPI instances for Local mode plugins


### PR DESCRIPTION
When calling `QProcess::terminate()`, Qt reports the process exit as `QProcess::CrashExit` with exit code 15 (SIGTERM) on Unix systems.
The core handles it as an error, logs critical errors and exits from the `QProcess::finished` handler.

As a result, plugin processes are not cleaned up correctly and remain running after the application is closed.

This PR fixes the issue by:

1- Treating CrashExit caused by SIGTERM as a normal and expected shutdown, with clearer log messages.
2- Preventing the application from exiting in this case, so plugin processes can be properly cleaned up and stopped.