### PR TITLE
discriminate dev and portable variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ nix build '.#logos-liblogos-include'
 
 # Build and run tests
 nix build '.#logos-liblogos-tests'
+
+# Build portable variant (selects portable LGX variants instead of dev)
+nix build '.#portable'
 ```
 
 #### Running Tests
@@ -194,6 +197,15 @@ The `logoscore` binary is the main entry point for the Logos Core application fr
 - Qt6 (qtbase) or Qt5 (Core, RemoteObjects)
 - Qt6 Remote Objects (qtremoteobjects)
 - [logos-cpp-sdk](https://github.com/logos-co/logos-cpp-sdk)
+
+## Dev vs Portable Builds
+
+The library supports two build modes controlled by the `LOGOS_PORTABLE_BUILD` CMake flag:
+
+- **Dev build** (default): Plugin loading looks for LGX variants with `-dev` suffix (e.g., `linux-amd64-dev`). Used in Nix/development environments.
+- **Portable build** (`-DLOGOS_PORTABLE_BUILD=ON`): Looks for portable variants without suffix (e.g., `linux-amd64`). Used in self-contained distributed applications.
+
+Build the portable variant with `nix build '.#portable'`.
 
 ## Supported Platforms
 

--- a/flake.lock
+++ b/flake.lock
@@ -11,6 +11,32 @@
         ]
       },
       "locked": {
+        "lastModified": 1773757961,
+        "narHash": "sha256-EOSmES7qytHrMlomRoTKBqSdSrJXUv3091OcstF8vL0=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "e49b879eb8f05d361e6876f357f1c793edc21bb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_2": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_2",
+        "logos-liblogos": "logos-liblogos_2",
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
         "lastModified": 1773696504,
         "narHash": "sha256-wBn8onAkEvtvl1McLVyFDSB8BRhUrwJAnnYIfXnIhdI=",
         "owner": "logos-co",
@@ -47,6 +73,24 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
+        "lastModified": 1773672219,
+        "narHash": "sha256-p+kv2WHokT40rScnSFSIDp/EeFLaDUsTHW6QT6ejKuc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "a4bd66cd6eb04ee7140bb940b1d49d72d60248de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
         "lastModified": 1761230734,
         "narHash": "sha256-CMRUwXH7pJZ1OI6bd/TDDDXKqQ1tQZHQEOOwK8TgYHI=",
         "owner": "logos-co",
@@ -60,9 +104,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_3": {
+    "logos-cpp-sdk_4": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1773672219,
@@ -78,9 +122,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_4": {
+    "logos-cpp-sdk_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1767724329,
@@ -96,10 +140,76 @@
         "type": "github"
       }
     },
+    "logos-cpp-sdk_6": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_8"
+      },
+      "locked": {
+        "lastModified": 1773672219,
+        "narHash": "sha256-p+kv2WHokT40rScnSFSIDp/EeFLaDUsTHW6QT6ejKuc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "a4bd66cd6eb04ee7140bb940b1d49d72d60248de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_7": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_9"
+      },
+      "locked": {
+        "lastModified": 1773672219,
+        "narHash": "sha256-p+kv2WHokT40rScnSFSIDp/EeFLaDUsTHW6QT6ejKuc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "a4bd66cd6eb04ee7140bb940b1d49d72d60248de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
     "logos-liblogos": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_2",
+        "logos-capability-module": "logos-capability-module_2",
+        "logos-cpp-sdk": "logos-cpp-sdk_4",
+        "logos-module": "logos-module",
+        "nix-bundle-appimage": "nix-bundle-appimage",
+        "nix-bundle-dir": "nix-bundle-dir_2",
         "nixpkgs": [
+          "logos-capability-module",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773696645,
+        "narHash": "sha256-GIb4xALCj3XK80rf6l89ZrZ/Y1YkqG1X/mfmVOUl/hw=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "5030aaaf86b89a382f3beb9426be4f8c2623215f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_2": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_3",
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-liblogos",
           "logos-cpp-sdk",
@@ -122,8 +232,10 @@
     },
     "logos-module": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_4",
+        "logos-cpp-sdk": "logos-cpp-sdk_5",
         "nixpkgs": [
+          "logos-capability-module",
+          "logos-liblogos",
           "logos-module",
           "logos-cpp-sdk",
           "nixpkgs"
@@ -143,10 +255,33 @@
         "type": "github"
       }
     },
+    "logos-module_2": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_7",
+        "nixpkgs": [
+          "logos-module",
+          "logos-cpp-sdk",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773758094,
+        "narHash": "sha256-bMhSAPE1AmYZRS0rkMJ02uycmUM75D7dCYJ49l/LPHQ=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "c836e03ac532231c4e48f44e890c61ae294c1edf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "nix-bundle-appimage": {
       "inputs": {
         "nix-bundle-dir": "nix-bundle-dir",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1772047346,
@@ -162,9 +297,30 @@
         "type": "github"
       }
     },
+    "nix-bundle-appimage_2": {
+      "inputs": {
+        "nix-bundle-dir": "nix-bundle-dir_3",
+        "nixpkgs": "nixpkgs_10"
+      },
+      "locked": {
+        "lastModified": 1772881966,
+        "narHash": "sha256-St49mpGrHh5UW1JAxHeqY49DvmubdVrG+H88tKG6jRg=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "5952460727bbfdb83446f24dc974460039a8a325",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir": {
       "inputs": {
         "nixpkgs": [
+          "logos-capability-module",
+          "logos-liblogos",
           "nix-bundle-appimage",
           "nixpkgs"
         ]
@@ -185,7 +341,46 @@
     },
     "nix-bundle-dir_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1771971384,
+        "narHash": "sha256-fq0H+sxQhkGN054jdN+ZfHZibbOjHA+KD5SpRH78T1g=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "1ecb9662145a1ad84007a970b4bef50a4af159c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771971384,
+        "narHash": "sha256-fq0H+sxQhkGN054jdN+ZfHZibbOjHA+KD5SpRH78T1g=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "1ecb9662145a1ad84007a970b4bef50a4af159c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_4": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1771971384,
@@ -208,6 +403,38 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1770562336,
+        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
         "type": "github"
       },
       "original": {
@@ -267,6 +494,22 @@
     },
     "nixpkgs_5": {
       "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
         "lastModified": 1771848320,
         "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
         "owner": "NixOS",
@@ -281,7 +524,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1770562336,
         "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
@@ -297,13 +540,45 @@
         "type": "github"
       }
     },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "logos-capability-module": "logos-capability-module",
-        "logos-cpp-sdk": "logos-cpp-sdk_3",
-        "logos-module": "logos-module",
-        "nix-bundle-appimage": "nix-bundle-appimage",
-        "nix-bundle-dir": "nix-bundle-dir_2",
+        "logos-cpp-sdk": "logos-cpp-sdk_6",
+        "logos-module": "logos-module_2",
+        "nix-bundle-appimage": "nix-bundle-appimage_2",
+        "nix-bundle-dir": "nix-bundle-dir_4",
         "nixpkgs": [
           "logos-cpp-sdk",
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -26,24 +26,41 @@
     {
       packages = forAllSystems ({ pkgs, system, logosSdk, capabilityModule, logosModule, dirBundler }:
         let
-          # Common configuration
+          # Common configuration (dev, default)
           common = import ./nix/default.nix { inherit pkgs logosSdk logosModule; };
+          # Common configuration (portable)
+          commonPortable = import ./nix/default.nix { inherit pkgs logosSdk logosModule; portableBuild = true; };
           src = ./.;
-          
-          # Shared build that compiles everything
+
+          # Shared build that compiles everything (dev)
           build = import ./nix/build.nix { inherit pkgs common src; };
-          
+
+          # Shared build (portable)
+          buildPortable = import ./nix/build.nix { inherit pkgs src; common = commonPortable; };
+
           # Individual package components (reference the shared build)
           lib = import ./nix/lib.nix { inherit pkgs common build; };
           modules = import ./nix/modules.nix { inherit pkgs common capabilityModule; };
+          modulesPortable = import ./nix/modules.nix { inherit pkgs capabilityModule; common = commonPortable; portableBuild = true; };
           bin = import ./nix/bin.nix { inherit pkgs common build lib modules; };
           include = import ./nix/include.nix { inherit pkgs common src logosSdk; };
           tests = import ./nix/tests.nix { inherit pkgs common build; };
-          
-          # Combined package
+
+          # Portable package components
+          libPortable = import ./nix/lib.nix { inherit pkgs; common = commonPortable; build = buildPortable; };
+          binPortable = import ./nix/bin.nix { inherit pkgs; common = commonPortable; build = buildPortable; lib = libPortable; modules = modulesPortable; };
+          includePortable = import ./nix/include.nix { inherit pkgs src logosSdk; common = commonPortable; };
+
+          # Combined package (dev)
           liblogos = pkgs.symlinkJoin {
             name = "logos-liblogos";
             paths = [ bin lib include ];
+          };
+
+          # Combined package (portable)
+          liblogosPortable = pkgs.symlinkJoin {
+            name = "logos-liblogos-portable";
+            paths = [ binPortable libPortable includePortable ];
           };
         in
         {
@@ -53,10 +70,13 @@
           logos-liblogos-include = include;
           logos-liblogos-tests = tests;
           logos-liblogos-modules = modules;
-          
+
           # Combined output
           logos-liblogos = liblogos;
-          
+
+          # Portable output (compiled with LOGOS_PORTABLE_BUILD)
+          portable = liblogosPortable;
+
           # Bundle outputs
           cli-bundle-dir = dirBundler bin;
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
@@ -68,7 +88,7 @@
             icon = ./assets/logoscore.png;
           };
         } // {
-          # Default package
+          # Default package (dev)
           default = liblogos;
         }
       );

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,40 +1,42 @@
 # Common build configuration shared across all packages
-{ pkgs, logosSdk, logosModule }:
+{ pkgs, logosSdk, logosModule, portableBuild ? false }:
 
 {
   pname = "logos-liblogos";
   version = "0.1.0";
-  
+
   # Common native build inputs
-  nativeBuildInputs = [ 
-    pkgs.cmake 
-    pkgs.ninja 
+  nativeBuildInputs = [
+    pkgs.cmake
+    pkgs.ninja
     pkgs.pkg-config
     pkgs.qt6.wrapQtAppsNoGuiHook
   ];
-  
+
   # Common runtime dependencies
-  buildInputs = [ 
-    pkgs.qt6.qtbase 
-    pkgs.qt6.qtremoteobjects 
+  buildInputs = [
+    pkgs.qt6.qtbase
+    pkgs.qt6.qtremoteobjects
     pkgs.zstd
     pkgs.gtest
     logosModule
   ];
-  
+
   # Common CMake flags
-  cmakeFlags = [ 
+  cmakeFlags = [
     "-GNinja"
     "-DLOGOS_CPP_SDK_ROOT=${logosSdk}"
     "-DLOGOS_MODULE_ROOT=${logosModule}"
+  ] ++ pkgs.lib.optionals portableBuild [
+    "-DLOGOS_PORTABLE_BUILD=ON"
   ];
-  
+
   # Environment variables
   env = {
     LOGOS_CPP_SDK_ROOT = "${logosSdk}";
     LOGOS_MODULE_ROOT = "${logosModule}";
   };
-  
+
   # Metadata
   meta = with pkgs.lib; {
     description = "Logos liblogos core library";

--- a/nix/modules.nix
+++ b/nix/modules.nix
@@ -1,6 +1,8 @@
 # Bundles modules from external flake inputs into the logoscore modules directory.
 # logoscore expects: modules/<name>/manifest.json + <name>_plugin.{so,dylib}
-{ pkgs, common, capabilityModule }:
+# When portableBuild is false (default/dev), manifest keys get a "-dev" suffix
+# to match the dev variant lookup in platformVariantsToTry().
+{ pkgs, common, capabilityModule, portableBuild ? false }:
 
 pkgs.runCommand "${common.pname}-modules-${common.version}"
   {
@@ -44,17 +46,20 @@ pkgs.runCommand "${common.pname}-modules-${common.version}"
       aarch64|arm64) arch="aarch64" ;;
     esac
 
+    # Dev builds use "-dev" suffixed variant keys to match platformVariantsToTry()
+    suffix="${if portableBuild then "" else "-dev"}"
+
     # Create manifest.json for plugin discovery
     cat > $out/modules/capability_module/manifest.json <<EOF
     {
       "name": "capability_module",
       "version": "1.0.0",
       "main": {
-        "$platform-$arch": "$pluginFile",
-        "$platform-amd64": "$pluginFile",
-        "$platform-arm64": "$pluginFile",
-        "$platform-x86_64": "$pluginFile",
-        "$platform-aarch64": "$pluginFile"
+        "$platform-$arch$suffix": "$pluginFile",
+        "$platform-amd64$suffix": "$pluginFile",
+        "$platform-arm64$suffix": "$pluginFile",
+        "$platform-x86_64$suffix": "$pluginFile",
+        "$platform-aarch64$suffix": "$pluginFile"
       }
     }
     EOF

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,12 @@ endif()
 # Set the LOGOS_CORE_LIBRARY definition for the library
 target_compile_definitions(logos_core PRIVATE LOGOS_CORE_LIBRARY)
 
+# Portable build: selects portable LGX variants instead of dev variants
+option(LOGOS_PORTABLE_BUILD "Build for portable variant selection" OFF)
+if(LOGOS_PORTABLE_BUILD)
+    target_compile_definitions(logos_core PRIVATE LOGOS_PORTABLE_BUILD=1)
+endif()
+
 # Link Qt libraries, SDK and module library
 target_link_libraries(logos_core PUBLIC 
     Qt${QT_VERSION_MAJOR}::Core 

--- a/src/logos_core/plugin_manager.cpp
+++ b/src/logos_core/plugin_manager.cpp
@@ -456,6 +456,14 @@ namespace PluginManager {
             variants << "linux-arm64";
         }
 
+#ifndef LOGOS_PORTABLE_BUILD
+        QStringList devVariants;
+        for (const QString &variant : variants) {
+            devVariants << (variant + "-dev");
+        }
+        variants = devVariants;
+#endif
+
         return variants;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,11 @@ target_include_directories(logos_core_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/src/logos_core
 )
 
+# Propagate portable build flag to tests so manifest variant keys match
+if(LOGOS_PORTABLE_BUILD)
+    target_compile_definitions(logos_core_tests PRIVATE LOGOS_PORTABLE_BUILD=1)
+endif()
+
 # Add SDK include directory (same logic as src/CMakeLists.txt)
 if(EXISTS "${LOGOS_CPP_SDK_ROOT}/lib" AND EXISTS "${LOGOS_CPP_SDK_ROOT}/include")
   target_include_directories(logos_core_tests PRIVATE 

--- a/tests/test_plugin_manager.cpp
+++ b/tests/test_plugin_manager.cpp
@@ -40,7 +40,11 @@ QString testPlatformVariant() {
 }
 
 QJsonObject mainFieldForPlatform(const QString &libName) {
-    return QJsonObject{{testPlatformVariant(), libName}};
+    QString variant = testPlatformVariant();
+#ifndef LOGOS_PORTABLE_BUILD
+    variant += "-dev";
+#endif
+    return QJsonObject{{variant, libName}};
 }
 }
 


### PR DESCRIPTION
Make Local (dev) builds only accept `-dev` variants of modules and Portable builds will only accept portable variants of modules.

This is a compile-time switch.

Most of these changes will go away when we split package scanning logic to a separate lib