### PR TITLE
fix stdout and stderr redirection

### DIFF
--- a/src/logos_core/plugin_launcher.cpp
+++ b/src/logos_core/plugin_launcher.cpp
@@ -1,6 +1,7 @@
 #include "plugin_launcher.h"
 #include "process_manager.h"
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 #include <filesystem>
 #include <cstdlib>
 #include <boost/dll/runtime_symbol_info.hpp>
@@ -8,6 +9,18 @@
 namespace fs = std::filesystem;
 
 namespace {
+
+    // Dedicated logger for child stdout — uses a pattern that prints a
+    // fictional "[out]" level, so stdout lines visually align with spdlog
+    // output but are clearly distinguished from stderr-classified lines.
+    std::shared_ptr<spdlog::logger>& moduleStdoutLogger() {
+        static std::shared_ptr<spdlog::logger> logger = []() {
+            auto l = spdlog::stdout_color_mt("logos_module_stdout");
+            l->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [out] %v");
+            return l;
+        }();
+        return logger;
+    }
 
     std::string resolveLogosHostPath(const std::vector<std::string>& pluginsDirs) {
         std::string logosHostPath;
@@ -85,16 +98,30 @@ namespace PluginLauncher {
         };
 
         callbacks.onOutput = [](const std::string& pName, const std::string& line, bool isStderr) {
-            if (isStderr) {
-                spdlog::critical("[{}] {}", pName, line);
-            } else if (line.find("Warning:") != std::string::npos ||
-                       line.find("WARNING:") != std::string::npos) {
-                spdlog::warn("[{}] {}", pName, line);
-            } else if (line.find("Critical:") != std::string::npos ||
-                       line.find("FAILED:") != std::string::npos ||
-                       line.find("ERROR:") != std::string::npos) {
-                spdlog::critical("[{}] {}", pName, line);
+            if (!isStderr) {
+                moduleStdoutLogger()->info("[{}] {}", pName, line);
+                return;
             }
+            auto contains = [&](std::initializer_list<const char*> keywords) {
+                for (const char* k : keywords)
+                    if (line.find(k) != std::string::npos) return true;
+                return false;
+            };
+            // stderr: map common level prefixes (Qt's default message handler,
+            // test/assertion frameworks, spdlog-style output from children)
+            // onto spdlog levels. Default to info when no prefix is recognised.
+            if (contains({"Critical:", "CRITICAL:", "Fatal:", "FATAL:"}))
+                spdlog::critical("[{}] {}", pName, line);
+            else if (contains({"Error:", "ERROR:", "FAILED:"}))
+                spdlog::error("[{}] {}", pName, line);
+            else if (contains({"Warning:", "WARNING:"}))
+                spdlog::warn("[{}] {}", pName, line);
+            else if (contains({"Debug:", "DEBUG:"}))
+                spdlog::debug("[{}] {}", pName, line);
+            else if (contains({"Trace:", "TRACE:"}))
+                spdlog::trace("[{}] {}", pName, line);
+            else
+                spdlog::info("[{}] {}", pName, line);
         };
 
         return QtProcessManager::startProcess(name, logosHostPath, arguments, callbacks);

--- a/src/logos_core/process_manager.cpp
+++ b/src/logos_core/process_manager.cpp
@@ -64,20 +64,25 @@ IoRuntime& ioRuntime() {
 
 struct ProcessEntry {
     bp2::process                           process;
-    asio::readable_pipe                    pipe;
+    asio::readable_pipe                    out_pipe;
+    asio::readable_pipe                    err_pipe;
     QtProcessManager::ProcessCallbacks     callbacks;
     std::string                            name;
-    std::array<char, 4096>                 read_buf{};
-    std::string                            line_buf;
+    std::array<char, 4096>                 out_read_buf{};
+    std::array<char, 4096>                 err_read_buf{};
+    std::string                            out_line_buf;
+    std::string                            err_line_buf;
     // Set by async_wait callback; used by syncKill to avoid double-waitpid.
     std::atomic<bool>                exited{false};
     // Set by terminateProcess/terminateAll to suppress onFinished callback.
     std::atomic<bool>                cancelled{false};
 
-    ProcessEntry(bp2::process proc, asio::readable_pipe rp,
+    ProcessEntry(bp2::process proc,
+                 asio::readable_pipe out_rp, asio::readable_pipe err_rp,
                  const std::string& n, const QtProcessManager::ProcessCallbacks& cb)
         : process(std::move(proc))
-        , pipe(std::move(rp))
+        , out_pipe(std::move(out_rp))
+        , err_pipe(std::move(err_rp))
         , name(n)
         , callbacks(cb)
     {}
@@ -108,44 +113,50 @@ std::string unixSocketPath(const std::string& name) {
 }
 
 // ---------------------------------------------------------------------------
-// Async read loop: reads merged stdout+stderr from child, fires onOutput per line.
+// Async read loop: reads stdout and stderr separately from child, fires
+// onOutput per line with the correct isStderr flag.
 // Called from the io_context thread.
 // ---------------------------------------------------------------------------
 
-void scheduleRead(std::shared_ptr<ProcessEntry> entry);
+void scheduleRead(std::shared_ptr<ProcessEntry> entry, bool isStderr);
 
-void handleRead(std::shared_ptr<ProcessEntry> entry,
+void handleRead(std::shared_ptr<ProcessEntry> entry, bool isStderr,
                 const boost::system::error_code& ec, std::size_t n)
 {
+    auto& buf      = isStderr ? entry->err_read_buf : entry->out_read_buf;
+    auto& line_buf = isStderr ? entry->err_line_buf : entry->out_line_buf;
+
     if (n > 0) {
-        entry->line_buf.append(entry->read_buf.data(), n);
+        line_buf.append(buf.data(), n);
         std::size_t pos = 0, nl;
-        while ((nl = entry->line_buf.find('\n', pos)) != std::string::npos) {
-            std::string line = entry->line_buf.substr(pos, nl - pos);
+        while ((nl = line_buf.find('\n', pos)) != std::string::npos) {
+            std::string line = line_buf.substr(pos, nl - pos);
             if (!line.empty() && line.back() == '\r') line.pop_back();
             if (!line.empty() && entry->callbacks.onOutput)
-                entry->callbacks.onOutput(entry->name, line, false);
+                entry->callbacks.onOutput(entry->name, line, isStderr);
             pos = nl + 1;
         }
-        entry->line_buf.erase(0, pos);
+        line_buf.erase(0, pos);
     }
 
     if (!ec) {
-        scheduleRead(std::move(entry));
+        scheduleRead(std::move(entry), isStderr);
     } else {
         // Pipe closed — flush any remaining partial line
-        if (!entry->line_buf.empty() && entry->callbacks.onOutput)
-            entry->callbacks.onOutput(entry->name, entry->line_buf, false);
-        entry->line_buf.clear();
+        if (!line_buf.empty() && entry->callbacks.onOutput)
+            entry->callbacks.onOutput(entry->name, line_buf, isStderr);
+        line_buf.clear();
     }
 }
 
-void scheduleRead(std::shared_ptr<ProcessEntry> entry) {
+void scheduleRead(std::shared_ptr<ProcessEntry> entry, bool isStderr) {
     auto* e = entry.get();
-    e->pipe.async_read_some(
-        asio::buffer(e->read_buf),
-        [entry = std::move(entry)](const boost::system::error_code& ec, std::size_t n) mutable {
-            handleRead(std::move(entry), ec, n);
+    auto& pipe = isStderr ? e->err_pipe : e->out_pipe;
+    auto& buf  = isStderr ? e->err_read_buf : e->out_read_buf;
+    pipe.async_read_some(
+        asio::buffer(buf),
+        [entry = std::move(entry), isStderr](const boost::system::error_code& ec, std::size_t n) mutable {
+            handleRead(std::move(entry), isStderr, ec, n);
         });
 }
 
@@ -196,7 +207,8 @@ void syncKill(std::shared_ptr<ProcessEntry> entry) {
     entry->cancelled.store(true);
 
     boost::system::error_code ec;
-    entry->pipe.close(ec); // cancel pending async_read
+    entry->out_pipe.close(ec); // cancel pending async_read on stdout
+    entry->err_pipe.close(ec); // cancel pending async_read on stderr
 
     entry->process.request_exit(ec); // SIGTERM
 
@@ -236,26 +248,34 @@ bool startProcess(const std::string& name, const std::string& executable,
 
     boost::system::error_code ec;
 
-    // Create a pipe: parent reads from rpipe; child writes to wpipe (stdout+stderr)
-    asio::readable_pipe rpipe(rt.ctx);
-    asio::writable_pipe wpipe(rt.ctx);
-    asio::connect_pipe(rpipe, wpipe, ec);
+    // Separate pipes for stdout and stderr so the reader can distinguish
+    // them (child's stdout → out_rpipe, child's stderr → err_rpipe).
+    asio::readable_pipe out_rpipe(rt.ctx), err_rpipe(rt.ctx);
+    asio::writable_pipe out_wpipe(rt.ctx), err_wpipe(rt.ctx);
+
+    asio::connect_pipe(out_rpipe, out_wpipe, ec);
     if (ec) {
-        fprintf(stderr, "[QtProcessManager] Failed to create pipe for %s: %s\n",
+        fprintf(stderr, "[QtProcessManager] Failed to create stdout pipe for %s: %s\n",
+                name.c_str(), ec.message().c_str());
+        return false;
+    }
+    asio::connect_pipe(err_rpipe, err_wpipe, ec);
+    if (ec) {
+        fprintf(stderr, "[QtProcessManager] Failed to create stderr pipe for %s: %s\n",
                 name.c_str(), ec.message().c_str());
         return false;
     }
 
-    // Redirect both stdout and stderr to wpipe (merged channels)
     bp2::process_stdio pstdio;
-    pstdio.out = wpipe;
-    pstdio.err = wpipe;
+    pstdio.out = out_wpipe;
+    pstdio.err = err_wpipe;
 
     // Use the launcher directly with ec as second arg (non-throwing variant)
     bp2::process proc = bp2::default_process_launcher()(rt.ctx, ec, executable, arguments, pstdio);
 
-    // Close write end in parent once child has inherited it
-    wpipe.close();
+    // Close write ends in parent once child has inherited them
+    out_wpipe.close();
+    err_wpipe.close();
 
     if (ec) {
         fprintf(stderr, "[QtProcessManager] Failed to start process for %s: %s\n",
@@ -264,7 +284,7 @@ bool startProcess(const std::string& name, const std::string& executable,
     }
 
     auto entry = std::make_shared<ProcessEntry>(
-        std::move(proc), std::move(rpipe), name, callbacks);
+        std::move(proc), std::move(out_rpipe), std::move(err_rpipe), name, callbacks);
 
     {
         std::lock_guard<std::mutex> lock(s_processesMutex);
@@ -272,7 +292,8 @@ bool startProcess(const std::string& name, const std::string& executable,
     }
 
     asio::post(rt.ctx, [entry]() {
-        scheduleRead(entry);
+        scheduleRead(entry, /*isStderr=*/false);
+        scheduleRead(entry, /*isStderr=*/true);
         scheduleWait(entry);
     });
 

--- a/src/logos_core/process_manager.cpp
+++ b/src/logos_core/process_manager.cpp
@@ -142,9 +142,13 @@ void handleRead(std::shared_ptr<ProcessEntry> entry, bool isStderr,
     if (!ec) {
         scheduleRead(std::move(entry), isStderr);
     } else {
-        // Pipe closed — flush any remaining partial line
-        if (!line_buf.empty() && entry->callbacks.onOutput)
-            entry->callbacks.onOutput(entry->name, line_buf, isStderr);
+        // Pipe closed — flush any remaining partial line (stripping a
+        // trailing CR, same as the newline loop above).
+        if (!line_buf.empty() && entry->callbacks.onOutput) {
+            if (line_buf.back() == '\r') line_buf.pop_back();
+            if (!line_buf.empty())
+                entry->callbacks.onOutput(entry->name, line_buf, isStderr);
+        }
         line_buf.clear();
     }
 }

--- a/tests/test_process_manager.cpp
+++ b/tests/test_process_manager.cpp
@@ -15,12 +15,18 @@
 // =============================================================================
 #include <gtest/gtest.h>
 #include "logos_core.h"
+#include "process_manager.h"
 #include "qt_test_adapter.h"
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <thread>
-#include <chrono>
 #include <unistd.h>
+#include <utility>
+#include <vector>
 
 static void clearProcessState() {
     logos_core_clear_processes();
@@ -193,6 +199,46 @@ TEST_F(ProcessManagerTest, MultipleProcesses_TerminateOneKeepsOther) {
 
     EXPECT_EQ(logos_core_has_process("kill_me"), 0);
     EXPECT_EQ(logos_core_has_process("keep_me"), 1);
+}
+
+// ---------------------------------------------------------------------------
+// onOutput: stdout and stderr are delivered with the correct isStderr flag
+// ---------------------------------------------------------------------------
+
+TEST_F(ProcessManagerTest, StartProcess_OnOutput_SplitsStdoutAndStderr) {
+    // Child writes one line to stdout and one to stderr, then exits.
+    // Verify both reach onOutput with the right isStderr flag.
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::vector<std::pair<std::string, bool>> lines; // (line, isStderr)
+    std::atomic<bool> finished{false};
+
+    QtProcessManager::ProcessCallbacks cb;
+    cb.onOutput = [&](const std::string& /*name*/, const std::string& line, bool isStderr) {
+        std::lock_guard<std::mutex> lock(mtx);
+        lines.emplace_back(line, isStderr);
+        cv.notify_all();
+    };
+    cb.onFinished = [&](const std::string& /*name*/, int /*code*/, bool /*crashed*/) {
+        finished.store(true);
+        cv.notify_all();
+    };
+
+    std::vector<std::string> args = {"-c", "echo out-line; echo err-line >&2"};
+    ASSERT_TRUE(QtProcessManager::startProcess("dualstream", "/bin/sh", args, cb));
+
+    std::unique_lock<std::mutex> lock(mtx);
+    cv.wait_for(lock, std::chrono::seconds(5),
+                [&]() { return finished.load() && lines.size() >= 2; });
+
+    ASSERT_GE(lines.size(), 2u);
+    bool saw_stdout = false, saw_stderr = false;
+    for (auto& [line, isStderr] : lines) {
+        if (!isStderr && line == "out-line") saw_stdout = true;
+        if ( isStderr && line == "err-line") saw_stderr = true;
+    }
+    EXPECT_TRUE(saw_stdout) << "stdout line missing or wrongly tagged";
+    EXPECT_TRUE(saw_stderr) << "stderr line missing or wrongly tagged";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Properly redirect modules' stderr (attempt to match lines to some spdlog level, print as Info by default).

Properly redirect modules' stdout (mimic spdlog format with fictional level `out`)

<img width="1672" height="334" alt="image" src="https://github.com/user-attachments/assets/d690a3f3-63c3-4e3f-967a-798a904b580f" />
