### PR TITLE
sendTokenToProcess: deadline-driven retry + sun_path length check

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776359718,
-        "narHash": "sha256-G2+MbYPictF9V9864KndteaEJzd8iUMktSzCphETabw=",
+        "lastModified": 1776882680,
+        "narHash": "sha256-g1E1L7Ac7PHUFuay/RDQDY2GZPy9lJotDG1MI15bOQ4=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "04b75c84b821662c9ae8f69967d4dd508e6d9e17",
+        "rev": "ecd369d48bffda2ad3c5233687603ef07d8b76a6",
         "type": "github"
       },
       "original": {

--- a/src/runtimes/runtime_qt/subprocess_manager.cpp
+++ b/src/runtimes/runtime_qt/subprocess_manager.cpp
@@ -111,7 +111,26 @@ struct IoRuntime {
     ~IoRuntime() {
         guard.reset();
         ctx.stop();
-        if (thread.joinable()) thread.join();
+        if (thread.joinable()) {
+            // Common case: destructor fires from the main thread at process
+            // exit, ctx.run() returned cleanly, just join.
+            //
+            // Pathological case: destructor fires from *this very thread*.
+            // Happens when an asio handler running on `thread` calls
+            // exit() (e.g. the onFinished callback below crash-aborts the
+            // process). exit() triggers static destruction in the calling
+            // thread; that's us. join() on yourself is EDEADLK and would
+            // throw a std::system_error → uncaught → terminate() → SIGABRT,
+            // masking the real crash that triggered the exit() in the first
+            // place. Detach instead: the OS reaps the thread on process
+            // exit, no observable difference vs join in this single-process
+            // scenario.
+            if (thread.get_id() == std::this_thread::get_id()) {
+                thread.detach();
+            } else {
+                thread.join();
+            }
+        }
     }
 };
 
@@ -471,7 +490,9 @@ bool SubprocessManager::startProcess(const std::string& name, const std::string&
     return true;
 }
 
-bool SubprocessManager::sendTokenToProcess(const std::string& name, const std::string& token)
+bool SubprocessManager::sendTokenToProcess(const std::string& name,
+                                            const std::string& token,
+                                            int max_wait_ms)
 {
     // Socket name is scoped by LOGOS_INSTANCE_ID so parallel Logos instances
     // (multiple daemons or Basecamp profiles) don't clash when loading the same
@@ -484,8 +505,47 @@ bool SubprocessManager::sendTokenToProcess(const std::string& name, const std::s
     }
     std::string path = unixSocketPath(socketName);
 
+    // Validate up front: sockaddr_un::sun_path is fixed-size
+    // (~104 bytes on macOS, ~108 on Linux). A long TMPDIR + module
+    // name + LOGOS_INSTANCE_ID combination overflows that buffer,
+    // and `strncpy(...sizeof(...) - 1)` below would silently
+    // truncate — leaving us connecting to a *different* (or
+    // nonexistent) socket while the child is bound to the full
+    // path. Fail loudly instead.
+    {
+        struct sockaddr_un sample{};
+        if (path.size() >= sizeof(sample.sun_path)) {
+            fprintf(stderr,
+                "[SubprocessManager] Unix socket path too long (%zu >= %zu): %s\n",
+                path.size(), sizeof(sample.sun_path), path.c_str());
+            std::shared_ptr<ProcessEntry> entry;
+            {
+                std::lock_guard<std::mutex> lock(s_processesMutex);
+                auto it = s_processes.find(name);
+                if (it != s_processes.end()) {
+                    entry = it->second;
+                    s_processes.erase(it);
+                }
+            }
+            syncKill(entry);
+            return false;
+        }
+    }
+
+    // Deadline-driven retry loop. Sleep 50ms between attempts — fine
+    // grained enough that a hot child (socket up before we finish our
+    // own setup) returns within a couple of polls, but the total
+    // budget is generous: previously a hard-coded 900ms (10 × 100ms),
+    // which was tight enough that we'd lose to cold-start child Qt
+    // initialisation under load and end up with "Failed to connect to
+    // token socket" + a half-loaded module. The 5s default covers
+    // realistic worst case (cold dylib load + Qt platform bring-up
+    // + plugin parse) with margin.
+    using clock = std::chrono::steady_clock;
+    const auto deadline = clock::now() + std::chrono::milliseconds(max_wait_ms);
+
     int sock = -1;
-    for (int attempt = 0; attempt < 10; ++attempt) {
+    for (;;) {
         sock = ::socket(AF_UNIX, SOCK_STREAM, 0);
         if (sock < 0) {
             fprintf(stderr, "[SubprocessManager] socket() failed: %s\n", strerror(errno));
@@ -494,6 +554,7 @@ bool SubprocessManager::sendTokenToProcess(const std::string& name, const std::s
 
         struct sockaddr_un addr{};
         addr.sun_family = AF_UNIX;
+        // Length already validated above — strncpy is safe here.
         strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
 
         if (::connect(sock, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0)
@@ -501,7 +562,8 @@ bool SubprocessManager::sendTokenToProcess(const std::string& name, const std::s
 
         ::close(sock);
         sock = -1;
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (clock::now() >= deadline) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
     if (sock < 0) {

--- a/src/runtimes/runtime_qt/subprocess_manager.h
+++ b/src/runtimes/runtime_qt/subprocess_manager.h
@@ -32,7 +32,21 @@ public:
     // -- Low-level static process management (used by tests / qt_test_adapter) --
     static bool startProcess(const std::string& name, const std::string& executable,
                              const std::vector<std::string>& arguments, const ProcessCallbacks& callbacks);
-    static bool sendTokenToProcess(const std::string& name, const std::string& token);
+    // Connect to the child's QtTokenReceiver Unix socket and write the
+    // auth token. The child binds the socket inside `setupModule` →
+    // `receiveAuthToken`, which runs *after* a non-trivial chain of
+    // child-side initialisation (dynamic loader, Qt platform bring-up,
+    // CLI11 parse, plugin loadFromPath). This call retries until the
+    // socket appears or the budget runs out.
+    //
+    // `max_wait_ms` is the total budget; defaults to 5 seconds, which
+    // comfortably covers cold-start child initialisation on realistic
+    // hardware. The previous 900 ms budget (10 × 100 ms) was tight
+    // enough that races against the child binding its socket were
+    // observable in the wild — see tests/test_subprocess_manager.cpp.
+    static bool sendTokenToProcess(const std::string& name,
+                                    const std::string& token,
+                                    int max_wait_ms = 5000);
     static void terminateProcess(const std::string& name);
     static void terminateAllProcesses();
     static bool hasProcess(const std::string& name);

--- a/tests/test_subprocess_manager.cpp
+++ b/tests/test_subprocess_manager.cpp
@@ -20,9 +20,14 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cerrno>       // for EINTR in the read-until-EOF loop
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>      // for strncpy
 #include <mutex>
 #include <string>
+#include <sys/socket.h>
+#include <sys/un.h>
 #include <thread>
 #include <unistd.h>
 #include <utility>
@@ -259,4 +264,128 @@ TEST_F(ProcessManagerTest, TerminateAll_RemovesAllRunningProcesses) {
     EXPECT_EQ(logos_core_has_process("ta_1"), 0);
     EXPECT_EQ(logos_core_has_process("ta_2"), 0);
     EXPECT_EQ(logos_core_has_process("ta_placeholder"), 0);
+}
+
+// ---------------------------------------------------------------------------
+// sendTokenToProcess: race against the child binding its Unix socket
+//
+// Real failure mode in production: the parent calls sendTokenToProcess
+// immediately after fork+exec, but the child has to do dynamic loader work,
+// Qt platform bring-up, CLI11 parse, and plugin loadFromPath before its
+// QtTokenReceiver binds the socket inside setupModule → receiveAuthToken.
+// Under load, that prelude exceeded the old 900ms budget (10 × 100ms) and
+// produced "Failed to connect to token socket" + a half-loaded module.
+// These tests pin down the new contract: a configurable max_wait_ms budget
+// that succeeds when the socket appears within it, and fails (without
+// busy-looping past the deadline) when it does not.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+std::string tokenSocketPath(const std::string& name) {
+    const char* tmp = std::getenv("TMPDIR");
+    std::string dir;
+    if (tmp && tmp[0]) {
+        dir = tmp;
+        while (!dir.empty() && dir.back() == '/') dir.pop_back();
+    } else {
+        dir = "/tmp";
+    }
+    std::string socketName = "logos_token_" + name;
+    const char* instanceId = std::getenv("LOGOS_INSTANCE_ID");
+    if (instanceId && *instanceId) {
+        socketName += "_";
+        socketName += instanceId;
+    }
+    return dir + "/" + socketName;
+}
+
+int bindUnixListener(const std::string& path) {
+    ::unlink(path.c_str());
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) return -1;
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+    if (::bind(fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    if (::listen(fd, 1) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+} // namespace
+
+TEST_F(ProcessManagerTest, SendToken_FailsFast_WhenSocketNeverAppears) {
+    const std::string name = "race_no_socket";
+    const std::string path = tokenSocketPath(name);
+    ::unlink(path.c_str());  // ensure no stale socket
+
+    const int budget_ms = 200;
+    const auto t0 = std::chrono::steady_clock::now();
+    bool ok = SubprocessManager::sendTokenToProcess(name, "tok", budget_ms);
+    const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    EXPECT_FALSE(ok) << "sendTokenToProcess must fail when no socket appears";
+    EXPECT_GE(elapsed_ms, budget_ms - 50) << "should respect the budget, not bail early";
+    EXPECT_LE(elapsed_ms, budget_ms + 500) << "should not loop past the deadline";
+}
+
+TEST_F(ProcessManagerTest, SendToken_SucceedsAfterDelay) {
+    const std::string name = "race_late_bind";
+    const std::string path = tokenSocketPath(name);
+    ::unlink(path.c_str());
+
+    const int delay_ms = 300;
+    const int budget_ms = 1500;
+
+    std::atomic<bool> received{false};
+    std::string receivedToken;
+    std::thread binder([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+        int listener = bindUnixListener(path);
+        if (listener < 0) return;
+        int client = ::accept(listener, nullptr, nullptr);
+        if (client >= 0) {
+            // Drain until EOF (sender's close()). A single ::read()
+            // can return short on stream sockets even when the sender
+            // wrote everything in one ::write() — kernel buffer
+            // fragmentation. Loop reads accumulate the full payload.
+            char buf[256];
+            for (;;) {
+                ssize_t n = ::read(client, buf, sizeof(buf));
+                if (n > 0) {
+                    receivedToken.append(buf, static_cast<std::size_t>(n));
+                    continue;
+                }
+                if (n == 0) break;          // peer closed
+                if (errno == EINTR) continue;
+                break;                       // unrecoverable read error
+            }
+            if (!receivedToken.empty()) received.store(true);
+            ::close(client);
+        }
+        ::close(listener);
+    });
+
+    const auto t0 = std::chrono::steady_clock::now();
+    bool ok = SubprocessManager::sendTokenToProcess(name, "hello-token", budget_ms);
+    const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    binder.join();
+    ::unlink(path.c_str());
+
+    EXPECT_TRUE(ok) << "should succeed once the socket appears within the budget";
+    EXPECT_GE(elapsed_ms, delay_ms - 50)
+        << "must wait until the listener is bound";
+    EXPECT_LT(elapsed_ms, budget_ms)
+        << "must complete before exhausting the budget";
+    EXPECT_TRUE(received.load());
+    EXPECT_EQ(receivedToken, "hello-token");
 }

--- a/tests/test_token_exchange.cpp
+++ b/tests/test_token_exchange.cpp
@@ -211,8 +211,14 @@ TEST_F(TokenExchangeTest, WrongName_FailsCleanlyWithinTimeout) {
     auto elapsed = std::chrono::duration_cast<Ms>(Clock::now() - start).count();
 
     EXPECT_EQ(sent, 0) << "sendToken to a nonexistent server must fail";
-    EXPECT_LT(elapsed, 5000)
-        << "sendToken must give up within its retry budget, got " << elapsed << "ms";
+    // The default budget is 5000 ms; with 50 ms polls the deadline check
+    // can overshoot by ~one poll interval before the loop exits, plus
+    // syscall and scheduler slack. 5500 ms is the budget + a single
+    // generous poll's worth of margin — far below the next-larger
+    // budget anyone reasonably picks (10 s+).
+    EXPECT_LT(elapsed, 5500)
+        << "sendToken must give up within its retry budget + slack, got "
+        << elapsed << "ms";
 
     // The failure path removes the placeholder entry.
     EXPECT_EQ(logos_core_has_process(moduleName.c_str()), 0);


### PR DESCRIPTION
Two related fixes to the parent-side token handoff to a child module process, both motivated by races / silent failures observed in the docker smoke matrix.

1. Replace the hard-coded 10×100ms retry loop with a deadline-driven loop, default budget 5000ms (configurable via a new max_wait_ms parameter). The previous 900ms cap was tight enough that on a cold child — dynamic loader + Qt platform bring-up + CLI11 parse + plugin loadFromPath — the parent would give up before the child bound its QtTokenReceiver socket, leaving a half-loaded module with a misleading "Failed to connect to token socket" error. New tests pin both ends of the contract: SendToken_FailsFast_WhenSocketNeverAppears  — bails within budget
       SendToken_SucceedsAfterDelay                — accepts late binders

   test_token_exchange's WrongName_FailsCleanlyWithinTimeout bound loosened from <5000ms to <5500ms because the deadline check can overshoot by ~one poll interval (50ms) plus syscall slack.

2. Validate the computed Unix socket path against sockaddr_un::sun_path (~104 bytes on macOS, ~108 on Linux) before strncpy. Long TMPDIR + module name + LOGOS_INSTANCE_ID combos would otherwise silently truncate, leaving the parent connecting to the wrong socket while the child binds the full path. Fail loudly instead.