### PR TITLE
fix(subprocess-manager): clear processes in ~IoRuntime to avoid shutd…

### DIFF
--- a/src/runtimes/runtime_qt/subprocess_manager.cpp
+++ b/src/runtimes/runtime_qt/subprocess_manager.cpp
@@ -108,30 +108,11 @@ struct IoRuntime {
         , thread([this]() { ctx.run(); })
     {}
 
-    ~IoRuntime() {
-        guard.reset();
-        ctx.stop();
-        if (thread.joinable()) {
-            // Common case: destructor fires from the main thread at process
-            // exit, ctx.run() returned cleanly, just join.
-            //
-            // Pathological case: destructor fires from *this very thread*.
-            // Happens when an asio handler running on `thread` calls
-            // exit() (e.g. the onFinished callback below crash-aborts the
-            // process). exit() triggers static destruction in the calling
-            // thread; that's us. join() on yourself is EDEADLK and would
-            // throw a std::system_error → uncaught → terminate() → SIGABRT,
-            // masking the real crash that triggered the exit() in the first
-            // place. Detach instead: the OS reaps the thread on process
-            // exit, no observable difference vs join in this single-process
-            // scenario.
-            if (thread.get_id() == std::this_thread::get_id()) {
-                thread.detach();
-            } else {
-                thread.join();
-            }
-        }
-    }
+    // Out-of-line — defined after s_processes so it can drop the live
+    // ProcessEntries (which hold asio handles tied to ctx) before
+    // letting ctx itself be destroyed. See the comment on s_processes
+    // below for the static-destruction-order rationale.
+    ~IoRuntime();
 };
 
 IoRuntime& ioRuntime() {
@@ -170,10 +151,59 @@ struct ProcessEntry {
 
 // ---------------------------------------------------------------------------
 // Global process registry
+//
+// Declared at namespace scope (constructed before main), while the
+// IoRuntime singleton above is a function-local static (constructed
+// lazily on first use, from main). C++ destroys statics in reverse
+// order of construction, so at exit ~IoRuntime fires first — tearing
+// down the asio::io_context (and its epoll_reactor) — and *then*
+// s_processes is destroyed, dropping its shared_ptr<ProcessEntry>s,
+// each of which closes asio handles (process / pipes) tied to the
+// already-freed reactor. Use-after-free → heap corruption → SIGABRT.
+// ~IoRuntime (defined below, out-of-line) handles this by clearing
+// s_processes itself while ctx is still alive.
 // ---------------------------------------------------------------------------
 
 std::unordered_map<std::string, std::shared_ptr<ProcessEntry>> s_processes;
 std::mutex s_processesMutex;
+
+// ---------------------------------------------------------------------------
+
+IoRuntime::~IoRuntime() {
+    guard.reset();
+    ctx.stop();
+    if (thread.joinable()) {
+        // Common case: destructor fires from the main thread at process
+        // exit, ctx.run() returned cleanly, just join.
+        //
+        // Pathological case: destructor fires from *this very thread*.
+        // Happens when an asio handler running on `thread` calls
+        // exit() (e.g. the onFinished callback below crash-aborts the
+        // process). exit() triggers static destruction in the calling
+        // thread; that's us. join() on yourself is EDEADLK and would
+        // throw a std::system_error → uncaught → terminate() → SIGABRT,
+        // masking the real crash that triggered the exit() in the first
+        // place. Detach instead: the OS reaps the thread on process
+        // exit, no observable difference vs join in this single-process
+        // scenario.
+        if (thread.get_id() == std::this_thread::get_id()) {
+            thread.detach();
+        } else {
+            thread.join();
+        }
+    }
+
+    // Tear down ProcessEntries while ctx (and its epoll_reactor) is
+    // still alive. See the static-destruction-order note on s_processes
+    // above. Doing this from ~IoRuntime instead of relying on the
+    // implicit reverse order of static destruction guarantees that
+    // every io_object_impl::~io_object_impl() (which calls
+    // reactor.deregister_descriptor) runs against a live reactor.
+    {
+        std::lock_guard<std::mutex> lock(s_processesMutex);
+        s_processes.clear();
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Unix domain socket path


### PR DESCRIPTION
…own UAF

`s_processes` is a namespace-scope static (constructed before main), while `IoRuntime` is a function-local static (constructed lazily on first use, from main). C++ destroys statics in reverse construction order, so at exit `~IoRuntime` fires first — tearing down the asio::io_context and its epoll_reactor — and then `~s_processes` runs, dropping `shared_ptr<ProcessEntry>`s whose dtors close asio handles tied to the already-freed reactor. The resulting use-after-free corrupts the heap and aborts logoscore on shutdown (SIGABRT 134 / sometimes SIGSEGV 139, glibc reports "corrupted size vs. prev_size"). Caught by valgrind:

    Invalid read of size 1
       at boost::asio::detail::epoll_reactor::deregister_descriptor
       by io_object_impl::~io_object_impl
       by std::_Hashtable<..., shared_ptr<ProcessEntry>, ...>::~_Hashtable
       by __cxa_finalize
     Address ... free'd
       by boost::asio::detail::epoll_reactor::~epoll_reactor
       by IoRuntime::~IoRuntime

Move ~IoRuntime out-of-line so it can reach s_processes, and have it clear the map after stopping the worker thread but before ctx itself is torn down by the field destructors. Each ProcessEntry's asio handles are now released against a live reactor; the later ~s_processes then runs against an empty map.

Surfaced by logos-test-modules: 149/158 tests failed in CI (intermittently 9–149 across machines, depending on malloc layout). With this fix: 158 passed, 0 failed.