### PR TITLE
Module crash handling

### DIFF
--- a/src/containers/subprocess/subprocess_container.cpp
+++ b/src/containers/subprocess/subprocess_container.cpp
@@ -296,21 +296,27 @@ bool SubprocessContainer::launch(const LogosCore::ModuleDescriptor& desc,
 {
     ProcessCallbacks callbacks;
 
+    // A crashing module must NOT take down the host: process isolation exists
+    // precisely so a module fault is contained. Treat a crash the same as a
+    // normal exit — log it and notify so the registry marks the module
+    // unloaded and the UI can react. (Calling exit() here also ran C++ static
+    // destructors / Qt plugin unload / GUI teardown from this boost::asio
+    // worker thread, racing the main thread and segfaulting.)
+    // `onTerminated` is documented as safe to invoke from a background thread
+    // (see ModuleRuntime::load); ModuleRegistry::markUnloaded is mutex-guarded.
     callbacks.onFinished = [onTerminated](const std::string& pName, int exitCode, bool crashed) {
         (void)exitCode;
-        if (crashed) {
+        if (crashed)
             spdlog::critical("Module process crashed: {}", pName);
-            exit(1);
-        }
         if (onTerminated)
             onTerminated(pName);
     };
 
-    callbacks.onError = [](const std::string& pName, bool crashed) {
-        if (crashed) {
+    callbacks.onError = [onTerminated](const std::string& pName, bool crashed) {
+        if (crashed)
             spdlog::critical("Module process crashed: {}", pName);
-            exit(1);
-        }
+        if (onTerminated)
+            onTerminated(pName);
     };
 
     callbacks.onOutput = [](const std::string& pName, const std::string& line, bool isStderr) {

--- a/src/runtimes/runtime_qt/host/logos_host.cpp
+++ b/src/runtimes/runtime_qt/host/logos_host.cpp
@@ -5,12 +5,99 @@
 #include "logos_api.h"
 #include "interface.h"
 
+#include <csignal>
+#include <cstring>
+
+#include <execinfo.h>
+#include <unistd.h>
+
+namespace {
+
+// Fatal signals that indicate the loaded module faulted.
+constexpr int kFatalSignals[] = { SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE };
+
+// Set once before handlers are installed; only ever read afterwards, so it is
+// safe to touch from an async-signal context. Points into main()'s `args`,
+// which outlives every point at which a fatal signal can be delivered.
+const char* g_crashModuleName = "unknown";
+
+// Alternate stack so a stack-overflow SIGSEGV (a common module crash) can still
+// run the handler instead of immediately re-faulting.
+char g_altStack[64 * 1024];
+
+// async-signal-safe: only write(2).
+void safeWrite(const char* s)
+{
+    if (!s) return;
+    const ssize_t n = ::write(STDERR_FILENO, s, std::strlen(s));
+    (void)n;
+}
+
+// Everything here is async-signal-safe: write(2), backtrace(3),
+// backtrace_symbols_fd(3), signal(2)/raise(3). No malloc, no strsignal.
+extern "C" void fatalSignalHandler(int sig)
+{
+    // "FATAL:" makes SubprocessContainer's onOutput classifier log this as
+    // critical, so a module crash is unmistakable in the Basecamp log.
+    safeWrite("\nFATAL: module '");
+    safeWrite(g_crashModuleName);
+    safeWrite("' crashed (signal ");
+
+    char numbuf[16];
+    int idx = static_cast<int>(sizeof(numbuf));
+    numbuf[--idx] = '\0';
+    int v = sig;
+    if (v == 0) {
+        numbuf[--idx] = '0';
+    } else {
+        while (v > 0 && idx > 0) { numbuf[--idx] = static_cast<char>('0' + v % 10); v /= 10; }
+    }
+    safeWrite(&numbuf[idx]);
+    safeWrite("). Backtrace:\n");
+
+    void* frames[64];
+    const int n = ::backtrace(frames, 64);
+    ::backtrace_symbols_fd(frames, n, STDERR_FILENO);
+    safeWrite("FATAL: end backtrace\n");
+
+    // Re-raise with the default disposition so the process still dies from the
+    // real signal: this keeps WIFSIGNALED true, so SubprocessContainer sees
+    // crashed=true and marks the module unloaded (host stays up).
+    ::signal(sig, SIG_DFL);
+    ::raise(sig);
+}
+
+void installCrashHandler(const char* moduleName)
+{
+    g_crashModuleName = (moduleName && *moduleName) ? moduleName : "unknown";
+
+    stack_t ss{};
+    ss.ss_sp    = g_altStack;
+    ss.ss_size  = sizeof(g_altStack);
+    ss.ss_flags = 0;
+    ::sigaltstack(&ss, nullptr);
+
+    struct sigaction sa{};
+    sa.sa_handler = &fatalSignalHandler;
+    sigemptyset(&sa.sa_mask);
+    // SA_RESETHAND: if the handler itself faults, the next delivery uses the
+    // default disposition and the process dies instead of looping.
+    sa.sa_flags = SA_RESETHAND | SA_ONSTACK;
+    for (const int s : kFatalSignals) {
+        ::sigaction(s, &sa, nullptr);
+    }
+}
+
+} // namespace
+
 int main(int argc, char *argv[])
 {
     ModuleArgs args = parseCommandLineArgs(argc, argv);
     if (!args.valid) {
         return 1;
     }
+
+    installCrashHandler(args.name.c_str());
 
     QtApp::init(argc, argv);
 

--- a/src/runtimes/runtime_qt/host/logos_host.cpp
+++ b/src/runtimes/runtime_qt/host/logos_host.cpp
@@ -5,8 +5,10 @@
 #include "logos_api.h"
 #include "interface.h"
 
+#include <cerrno>
 #include <csignal>
-#include <cstring>
+#include <cstddef>
+#include <cstdint>
 
 #include <execinfo.h>
 #include <unistd.h>
@@ -25,16 +27,58 @@ const char* g_crashModuleName = "unknown";
 // run the handler instead of immediately re-faulting.
 char g_altStack[64 * 1024];
 
-// async-signal-safe: only write(2).
+// async-signal-safe: write(2) only. Inlines NUL scan and the EINTR /
+// partial-write loop so the handler never touches libc symbols whose
+// async-signal-safety POSIX does not guarantee — std::strlen, strerror,
+// stdio. Best-effort: on persistent write failure we just return; we
+// are already in a fatal signal handler about to re-raise.
 void safeWrite(const char* s)
 {
     if (!s) return;
-    const ssize_t n = ::write(STDERR_FILENO, s, std::strlen(s));
-    (void)n;
+    std::size_t n = 0;
+    while (s[n] != '\0') ++n;
+    while (n > 0) {
+        const ssize_t w = ::write(STDERR_FILENO, s, n);
+        if (w <= 0) {
+            if (w < 0 && errno == EINTR) continue;
+            return;
+        }
+        s += w;
+        n -= static_cast<std::size_t>(w);
+    }
 }
 
-// Everything here is async-signal-safe: write(2), backtrace(3),
-// backtrace_symbols_fd(3), signal(2)/raise(3). No malloc, no strsignal.
+// async-signal-safe hex emit of a pointer value. Avoids snprintf (not on
+// the POSIX async-signal-safe list) and any libc string formatting.
+void safeWriteHex(const void* p)
+{
+    char hex[2 + 16 + 1];  // "0x" + 16 hex digits + NUL
+    hex[sizeof(hex) - 1] = '\0';
+    int idx = static_cast<int>(sizeof(hex)) - 1;
+    std::uintptr_t v = reinterpret_cast<std::uintptr_t>(p);
+    if (v == 0) {
+        hex[--idx] = '0';
+    } else {
+        while (v > 0 && idx > 2) {
+            const int d = static_cast<int>(v & 0xF);
+            hex[--idx] = static_cast<char>(d < 10 ? '0' + d : 'a' + d - 10);
+            v >>= 4;
+        }
+    }
+    hex[--idx] = 'x';
+    hex[--idx] = '0';
+    safeWrite(&hex[idx]);
+}
+
+// Everything here is async-signal-safe: write(2), backtrace(3) (writes
+// only into our own stack array — no libc string allocation), signal(2)
+// / raise(3). Deliberately NOT calling backtrace_symbols_fd: it invokes
+// dladdr() to resolve symbols, which takes the loader lock. A crash that
+// happens while the crashing thread already holds that lock (e.g. inside
+// dlopen) would deadlock the handler here. Frames are emitted as raw
+// addresses instead — decode after the fact with `atos -p <pid> <addr>`
+// (macOS) or `addr2line -e <bin> <addr>` (Linux). Same trade-off
+// Chromium / Firefox / Breakpad make for the same reason.
 extern "C" void fatalSignalHandler(int sig)
 {
     // "FATAL:" makes SubprocessContainer's onOutput classifier log this as
@@ -53,11 +97,15 @@ extern "C" void fatalSignalHandler(int sig)
         while (v > 0 && idx > 0) { numbuf[--idx] = static_cast<char>('0' + v % 10); v /= 10; }
     }
     safeWrite(&numbuf[idx]);
-    safeWrite("). Backtrace:\n");
+    safeWrite("). Backtrace (raw addresses; decode with atos/addr2line):\n");
 
     void* frames[64];
     const int n = ::backtrace(frames, 64);
-    ::backtrace_symbols_fd(frames, n, STDERR_FILENO);
+    for (int i = 0; i < n; ++i) {
+        safeWrite("  ");
+        safeWriteHex(frames[i]);
+        safeWrite("\n");
+    }
     safeWrite("FATAL: end backtrace\n");
 
     // Re-raise with the default disposition so the process still dies from the

--- a/tests/test_subprocess_container.cpp
+++ b/tests/test_subprocess_container.cpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <csignal>
 #include <cstdint>
 #include <mutex>
 #include <string>
@@ -211,6 +212,65 @@ TEST_F(SubprocessContainerTest, Launch_OutputCallbackReceivesStdoutAndStderr) {
     }
     EXPECT_TRUE(saw_stdout);
     EXPECT_TRUE(saw_stderr);
+}
+
+// ---------------------------------------------------------------------------
+// Crash detection — the kernel of crash isolation
+// ---------------------------------------------------------------------------
+//
+// When a child dies on a signal, the container must surface it via
+// onFinished(name, exit_code, crashed=true) and tear down its own
+// bookkeeping. Every observer above (composite_runtime → module_manager's
+// onTerminated → registry.markUnloaded → daemon → CLI) hangs off this
+// callback — if it stops firing with crashed=true, isolation breaks
+// silently. The end-to-end test in logos-logoscore-cli covers the full
+// stack at ~13s; this one pins the mechanism at its source in ~50ms.
+
+TEST_F(SubprocessContainerTest, Launch_OnFinishedReportsCrashedOnSignal) {
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::atomic<bool> fired{false};
+    std::string gotName;
+    int gotExitCode = -1;
+    bool gotCrashed = false;
+
+    SubprocessContainer::ProcessCallbacks cb;
+    cb.onFinished = [&](const std::string& n, int code, bool crashed) {
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            gotName = n;
+            gotExitCode = code;
+            gotCrashed = crashed;
+        }
+        fired.store(true);
+        cv.notify_all();
+    };
+
+    // `kill -SEGV $$` makes the shell signal itself — a portable way to
+    // exercise WIFSIGNALED without depending on /bin/kill -s SEGV syntax
+    // or shipping a custom helper binary.
+    ASSERT_TRUE(SubprocessContainer::startProcess(
+        "crash_test", "/bin/sh", {"-c", "kill -SEGV $$"}, cb));
+
+    std::unique_lock<std::mutex> lock(mtx);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&]() { return fired.load(); }))
+        << "onFinished never fired for a signaled child";
+
+    EXPECT_EQ(gotName, "crash_test");
+    EXPECT_TRUE(gotCrashed)
+        << "container must report crashed=true on signal-exit (WIFSIGNALED). "
+           "Without this, the markUnloaded propagation up the stack stalls "
+           "and a crashed module looks 'loaded' forever.";
+    EXPECT_EQ(gotExitCode, SIGSEGV)
+        << "exit_code must carry the signal number (WTERMSIG), not the "
+           "raw waitpid status. Got " << gotExitCode << ".";
+
+    // Bookkeeping side of the contract: once onFinished has fired the
+    // container must no longer claim the module exists. This is what
+    // feeds upstream observers via their own ProcessEntry cleanup.
+    EXPECT_FALSE(container.hasModule("crash_test"));
+    EXPECT_FALSE(container.pid("crash_test").has_value());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- Don't take down the main thread when a module process crashes
- Print backtrace when a module process crashes