### PR TITLE
chore: bump logos-cpp-sdk (provider event threading fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -195,11 +195,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "lastModified": 1779716125,
+        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-cpp-sdk` → `d77c3dd` to pick up logos-co/logos-cpp-sdk#68 (marshals provider event emission onto the remoting source thread).

This is the `logos-core` runtime where the module's `ModuleProxy` runs, so it needs the fix for the `start` hang (logos-delivery-module#44). `flake.lock`-only.