### PR TITLE
test: assert auto-resolution leaves transitive dep closure loaded

### DIFF
--- a/tests/test_module_runtime_abstraction.cpp
+++ b/tests/test_module_runtime_abstraction.cpp
@@ -215,6 +215,39 @@ TEST_F(ModuleRuntimeAbstractionTest, LoadWithDeps_SkipsAlreadyLoadedModules) {
     EXPECT_EQ(fake->loadCalls[0], "b");
 }
 
+// LoadsInTopologicalOrder (above) pins the *call sequence*. This one pins the
+// *observable end state*: requesting a single top-level module with
+// with_dependencies=true must leave that module's entire transitive
+// dependency closure loaded, as reported by the public query API. This is the
+// guarantee callers actually rely on ("load app, get everything it needs"),
+// and it exercises a diamond (app → ui, core; ui → core) so a dependency
+// reachable by two paths is still loaded exactly once and not skipped.
+TEST_F(ModuleRuntimeAbstractionTest, LoadWithDeps_LeavesTransitiveClosureLoaded) {
+    registerModule("core");
+    registerModule("ui",  {"core"});
+    registerModule("app", {"ui", "core"});
+
+    // Precondition: nothing in the closure is loaded yet.
+    ASSERT_EQ(logos_core_is_module_loaded("app"),  0);
+    ASSERT_EQ(logos_core_is_module_loaded("ui"),   0);
+    ASSERT_EQ(logos_core_is_module_loaded("core"), 0);
+
+    // Only the top module is requested.
+    int result = logos_core_load_module("app", true);
+    ASSERT_EQ(result, 1);
+
+    // The whole closure ends up loaded — the deps were auto-resolved.
+    EXPECT_EQ(logos_core_is_module_loaded("app"),  1);
+    EXPECT_EQ(logos_core_is_module_loaded("ui"),   1);
+    EXPECT_EQ(logos_core_is_module_loaded("core"), 1);
+
+    // The diamond's shared dependency loads exactly once despite two paths.
+    int coreLoads = 0;
+    for (const auto& n : fake->loadCalls)
+        if (n == "core") ++coreLoads;
+    EXPECT_EQ(coreLoads, 1);
+}
+
 // =============================================================================
 // terminateAll routing
 // =============================================================================


### PR DESCRIPTION
## What

Adds a direct test that loading a module with `with_dependencies=true` leaves its **entire transitive dependency closure loaded**, asserted through the public `logos_core_is_module_loaded` query.

## Why

`test_module_runtime_abstraction.cpp` already had `LoadWithDeps_LoadsInTopologicalOrder`, which pins the *load call sequence*. But nothing pinned the **observable end state** — i.e. the guarantee callers actually rely on: "load the top module, and everything it needs ends up loaded."

This gap came up while auditing whether automatic dependency resolution on module load is tested. The resolver algorithm (`test_dependency_resolver.cpp`) and the C-API failure modes (`test_module_manager.cpp` `LoadModuleWithDeps_*`) were covered, but the positive "unloaded deps become loaded" outcome was only implied by the call-sequence test.

## What it adds

`LoadWithDeps_LeavesTransitiveClosureLoaded`:
- Builds a diamond: `app → {ui, core}`, `ui → core`.
- Asserts the closure starts unloaded.
- Loads **only** `app` with `with_dependencies=true`.
- Asserts `app`, `ui`, and `core` are all loaded afterward.
- Asserts the diamond's shared dep `core` is loaded **exactly once** despite two reachability paths.

No new infrastructure — reuses the existing `FakeRuntime` fixture, so no subprocesses or Qt Remote Objects.

`ws test logos-liblogos` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)