### PR TITLE
add api for access policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ void logos_core_set_persistence_base_path(const char* path);
 // before the module is loaded.
 void logos_core_set_module_transports(const char* name, const char* transport_set_json);
 
+// Inter-module access policy (per-target allowed-caller allowlists).
+// Should be called before the modules are loaded. NULL/"" clears it.
+// NOTE: currently a no-op — accepted but not yet enforced (TODO).
+void logos_core_set_access_policy(const char* policy_json);
+
 // Module management
 int  logos_core_load_module(const char* name, bool with_dependencies);
 int  logos_core_unload_module(const char* name, bool with_dependents);

--- a/docs/project.md
+++ b/docs/project.md
@@ -313,6 +313,7 @@ The public C API (`logos_core.h`) is the only exported interface. All functions 
 | `logos_core_add_modules_dir(dir)` | Add a module directory to scan (duplicates ignored) |
 | `logos_core_set_persistence_base_path(path)` | Set base directory for module instance persistence |
 | `logos_core_set_module_transports(name, json)` | Register a per-module transport set (JSON, see logos-cpp-sdk shape). Forwarded to the child via `--transport-set` so its `LogosAPIProvider` binds every listener instead of only the global default LocalSocket. Must be called before the module is loaded; empty clears the entry |
+| `logos_core_set_access_policy(json)` | Install the inter-module access policy (version + mode + per-target `allowedCallers` allowlists). Should be called before modules are loaded; NULL/empty clears it. **Currently a no-op** — accepted but not yet enforced (TODO) |
 | `logos_core_load_module(name, with_dependencies) → int` | Load a module (1 = success, 0 = failure). When `with_dependencies` is true, resolves the dependency tree and loads in topological order |
 | `logos_core_unload_module(name, with_dependents) → int` | Unload a module. When `with_dependents` is true, cascade unloads every loaded transitive dependent leaves-first. Returns 1 only if every step succeeded |
 | `logos_core_get_module_dependencies(name, recursive) → char**` | Modules that `name` depends on (forward edges). `recursive=true` walks the forward graph transitively. Unknown names yield an empty array. Caller frees |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -245,6 +245,7 @@ The platform supports two build variants:
 | `logos_core_get_module_dependents(name, recursive) → char**` | Return null-terminated array of modules that depend on `name` (reverse edges). With `recursive=true`, walks the reverse dependency graph transitively via BFS. Unknown names yield an empty array. Caller must free. |
 | `logos_core_process_module(path) → char*` | Read a module file's metadata and register it as known without loading. Returns the module name or NULL. Caller must free. |
 | `logos_core_set_module_transports(name, json)` | Register a per-module `LogosTransportSet` (JSON, see logos-cpp-sdk shape) for the named module. The runtime forwards it to the child via `--transport-set` so the child's `LogosAPIProvider` binds every transport instead of only the global default LocalSocket. Must be called before the module is loaded. NULL or empty clears any previously-registered entry. |
+| `logos_core_set_access_policy(json)` | Install the inter-module access policy: a JSON document with `version`, `mode` (e.g. `enforce`), and `restrictions` mapping each target module to its `allowedCallers` allowlist. Should be called before modules are loaded. NULL or empty clears any previously-set policy. **Currently a no-op** — the policy is accepted but not yet enforced (TODO). |
 
 ### Token and Monitoring
 

--- a/src/logos_core/logos_core.cpp
+++ b/src/logos_core/logos_core.cpp
@@ -102,6 +102,19 @@ void logos_core_set_module_transports(const char* module_name,
         transport_set_json ? std::string(transport_set_json) : std::string{});
 }
 
+void logos_core_set_access_policy(const char* policy_json) {
+    // No-op for now: the policy is accepted but not yet enforced. A NULL
+    // or empty argument is the documented "clear the policy" signal, so
+    // it's explicitly allowed (unlike the module-name setters above, this
+    // does not abort on NULL).
+    //
+    // TODO: Parse `policy_json` (version / mode / per-target
+    // allowedCallers) and enforce the per-target allowed-caller checks
+    // on the inter-module call path. Until then, every call is permitted
+    // regardless of the policy supplied here.
+    (void)policy_json;
+}
+
 void logos_core_refresh_modules()
 {
     ModuleManager::discoverInstalledModules();

--- a/src/logos_core/logos_core.h
+++ b/src/logos_core/logos_core.h
@@ -105,6 +105,34 @@ LOGOS_CORE_EXPORT void logos_core_set_persistence_base_path(const char* path);
 LOGOS_CORE_EXPORT void logos_core_set_module_transports(const char* module_name,
                                                          const char* transport_set_json);
 
+// Install the inter-module access policy that governs which caller
+// modules may invoke which target modules.
+//
+// `policy_json` is a JSON document of the shape:
+//
+//     {
+//       "version": 1,
+//       "mode": "enforce",
+//       "restrictions": {
+//         "package_manager":    { "allowedCallers": ["package_manager_ui"] },
+//         "package_downloader": { "allowedCallers": ["package_manager_ui"] }
+//       }
+//     }
+//
+// `mode` selects how violations are handled (e.g. "enforce" to deny,
+// other modes may log only). Each entry under `restrictions` names a
+// target module and the set of caller modules permitted to reach it;
+// a target absent from `restrictions` is unrestricted.
+//
+// Should be called before logos_core_start() so the policy is in place
+// before any module is loaded. NULL or "" clears any previously-set
+// policy.
+//
+// TODO: This is currently a no-op — the policy is accepted but not yet
+// enforced. Implement parsing of the JSON document and wire the
+// per-target allowed-caller checks into the inter-module call path.
+LOGOS_CORE_EXPORT void logos_core_set_access_policy(const char* policy_json);
+
 // Re-scan all module directories and update known modules.
 // Call after installing new modules so they become discoverable.
 LOGOS_CORE_EXPORT void logos_core_refresh_modules();

--- a/tests/test_app_lifecycle.cpp
+++ b/tests/test_app_lifecycle.cpp
@@ -115,3 +115,59 @@ TEST_F(AppLifecycleTest, Start_UsesCustomModulesDirs) {
     EXPECT_EQ(std::string(dir), "/custom/modules");
     delete[] dir;
 }
+
+// =============================================================================
+// Access Policy Tests
+// =============================================================================
+//
+// logos_core_set_access_policy is currently a no-op: the policy is
+// accepted but not yet enforced (see the TODO in logos_core.cpp). These
+// tests don't assert any behavioural effect — there's nothing to observe
+// yet — but they pin the contract that already holds: the call accepts a
+// well-formed policy, an empty string, and NULL (the documented "clear"
+// signal) without crashing or aborting, and without disturbing unrelated
+// core state. When enforcement lands, these become the scaffold for
+// asserting the policy actually gates calls.
+
+TEST_F(AppLifecycleTest, SetAccessPolicy_AcceptsValidPolicyWithoutCrashing) {
+    const char* policy =
+        "{\"version\":1,\"mode\":\"enforce\",\"restrictions\":{"
+        "\"package_manager\":{\"allowedCallers\":[\"package_manager_ui\"]},"
+        "\"package_downloader\":{\"allowedCallers\":[\"package_manager_ui\"]}}}";
+
+    // No-op today: the only contract is "doesn't crash, doesn't throw".
+    EXPECT_NO_THROW(logos_core_set_access_policy(policy));
+}
+
+TEST_F(AppLifecycleTest, SetAccessPolicy_AcceptsEmptyStringAsClear) {
+    EXPECT_NO_THROW(logos_core_set_access_policy(""));
+}
+
+TEST_F(AppLifecycleTest, SetAccessPolicy_AcceptsNullAsClear) {
+    // Unlike the module-name setters, this one must NOT abort on NULL —
+    // NULL is the documented "clear the policy" signal.
+    EXPECT_NO_THROW(logos_core_set_access_policy(nullptr));
+}
+
+TEST_F(AppLifecycleTest, SetAccessPolicy_IsIdempotentAcrossRepeatedCalls) {
+    // Setting then clearing then re-setting must be safe in any order.
+    EXPECT_NO_THROW(logos_core_set_access_policy("{\"version\":1}"));
+    EXPECT_NO_THROW(logos_core_set_access_policy(nullptr));
+    EXPECT_NO_THROW(logos_core_set_access_policy(""));
+    EXPECT_NO_THROW(logos_core_set_access_policy("{\"version\":1}"));
+}
+
+TEST_F(AppLifecycleTest, SetAccessPolicy_DoesNotDisturbModulesDirs) {
+    logos_core_add_modules_dir("/custom/modules");
+    ASSERT_EQ(logos_core_get_modules_dirs_count(), 1);
+
+    logos_core_set_access_policy(
+        "{\"version\":1,\"mode\":\"enforce\",\"restrictions\":{}}");
+
+    // The policy setter touches nothing else in core state.
+    EXPECT_EQ(logos_core_get_modules_dirs_count(), 1);
+    char* dir = logos_core_get_modules_dir_at(0);
+    ASSERT_NE(dir, nullptr);
+    EXPECT_EQ(std::string(dir), "/custom/modules");
+    delete[] dir;
+}


### PR DESCRIPTION
This is to be used by the clients to enforce certain inter module access policies they might want to force (for e.g only X is allowed to call the package manager). It's a no-op for now, but useful to add support in the clients first, then continue implementing in this layer and above. Generally we're taking an iterative approach towards capabilities.