### PR TITLE
add draft doctest showing how to use liblogos as a library

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -1,10 +1,14 @@
 name: liblogos Doc-Tests
 
-# Runs the executable liblogos doc-test (doctests/liblogos-module-runtime.test.yaml)
-# end-to-end via the shared doctest CLI: builds the logoscore runtime against the
-# commit of logos-liblogos under test (via --override-input), builds lgpm, packages
-# and installs the real accounts module, starts the daemon, loads the module, calls
-# its methods, and asserts on the output.
+# Runs the executable liblogos doc-tests end-to-end via the shared doctest CLI,
+# both pinned to the commit of logos-liblogos under test (via --release-for):
+#   - doctests/liblogos-module-runtime.test.yaml — drives liblogos through the
+#     logoscore CLI frontend (build logoscore against this commit, install the
+#     accounts module, start the daemon, load + call methods).
+#   - doctests/liblogos-as-a-library.test.yaml — embeds liblogos directly:
+#     builds liblogos_core from this commit, compiles a C++ program that links
+#     it, installs modules with lgpm, and loads the accounts module via the C API.
+# Both specs run in one invocation, producing a single combined report.
 #
 # ──────────────────────────────────────────────────────────────────────────────
 # One-time setup required for the clickable report links to work:
@@ -85,17 +89,20 @@ jobs:
       # (+ rich), so no pip install step is needed.
       #
       # --release-for pins the {release} placeholder for logos-liblogos to the
-      # commit under test, so the override URL in the spec
+      # commit under test, so the override URL in each spec
       # (`github:logos-co/logos-liblogos{release}`) becomes `.../<sha>` — the
-      # logoscore runtime is rebuilt against this PR/push rather than master.
-      # Every other repo URL still resolves to latest.
-      - name: Run liblogos module-runtime doc-test
+      # logoscore runtime and the embedded liblogos_core are both rebuilt against
+      # this PR/push rather than master. Every other repo URL still resolves to
+      # latest. Passing both specs to one `run` produces a single combined report
+      # with a per-spec dropdown.
+      - name: Run liblogos doc-tests
         run: |
           # --continue-on-fail so the run walks every step and the published
           # report is complete. The job still fails (non-zero exit) if any step
           # failed; this only changes whether we stop early.
           nix run github:logos-co/logos-doctest -- run \
             doctests/liblogos-module-runtime.test.yaml \
+            doctests/liblogos-as-a-library.test.yaml \
             --verbose \
             --continue-on-fail \
             --release-for logos-liblogos=${{ steps.commit.outputs.sha }} \
@@ -128,6 +135,11 @@ jobs:
             --release-for logos-liblogos=${{ steps.commit.outputs.sha }} \
             -o /tmp/liblogos-module-runtime.md
           test -s /tmp/liblogos-module-runtime.md
+          nix run github:logos-co/logos-doctest -- generate \
+            doctests/liblogos-as-a-library.test.yaml \
+            --release-for logos-liblogos=${{ steps.commit.outputs.sha }} \
+            -o /tmp/liblogos-as-a-library.md
+          test -s /tmp/liblogos-as-a-library.md
           echo "Generated markdown successfully"
 
   publish-report:

--- a/doctests/liblogos-as-a-library.test.yaml
+++ b/doctests/liblogos-as-a-library.test.yaml
@@ -1,0 +1,361 @@
+name: "Embedding This liblogos as a Library"
+output: liblogos-as-a-library.md
+release: ""
+
+intro: |
+  # WARNING
+    ** IMPORTANT **
+    This doctest is for internal dev purposes and should not be used. It displays important flaws that will be corrected, specifically that QCoreApplication should no longer be needed but it's pending some changes still at which point this doctest will be updated to reflect that
+    ** IMPORTANT **
+  `logos-liblogos` is a **library**. The headless `logoscore` CLI and the
+  basecamp desktop app are just frontends for it — each one links
+  `liblogos_core` and drives its C API (`logos_core.h`) to discover, load, and
+  manage modules. This doc-test shows how to do the same thing in **your own
+  program**, built against **this** liblogos commit:
+
+  1. Build `liblogos_core` (the C-API shared library), its `logos_host`
+     subprocess binary, and the `logos_core.h` header — all from the commit
+     under test.
+  2. Build the `lgpm` package manager and install two real modules
+     ([`capability_module`](https://github.com/logos-co/logos-capability-module)
+     and [`accounts_module`](https://github.com/logos-co/logos-accounts-module))
+     into a local modules directory.
+  3. Write a ~50-line C++ program that links `liblogos_core`, then calls the C
+     API to start the runtime and load `accounts_module`.
+  4. Build that program against this liblogos and run it — watching the module
+     come up over liblogos' own IPC.
+
+  Because the library, the host binary, and the headers all come from the commit
+  under test, a green run is direct evidence that **this** liblogos is usable as
+  an embeddable library, not just through the `logoscore` frontend.
+
+  > **Why C++ and not pure C?** The API in `logos_core.h` is plain C, but the
+  > runtime is built on Qt internally (it uses `QPluginLoader` to read module
+  > metadata and Qt's IPC stack to talk to modules). So an embedding program must
+  > construct a `QCoreApplication` before it calls `logos_core_start()` — exactly
+  > as `logoscore` and basecamp do. You do **not** need to run Qt's event loop;
+  > the load calls are synchronous.
+
+what_you_build: "A standalone C++ program that links `liblogos_core` from this commit and loads the real `accounts_module` through the C API."
+
+what_you_learn:
+  - How to build `liblogos_core`, `logos_host`, and `logos_core.h` from a specific liblogos commit
+  - What a minimal `CMakeLists.txt` that links `liblogos_core` looks like
+  - "The lifecycle of the C API: `logos_core_init` → `add_modules_dir` → `start` → `load_module` → `cleanup`"
+  - Why an embedding program needs a `QCoreApplication`, and where `logos_host` fits in (`LOGOS_HOST_PATH`)
+  - How to install modules with `lgpm` so the runtime can discover them
+
+prerequisites:
+  - |
+    **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then enable flakes:
+
+    ```bash
+    mkdir -p ~/.config/nix
+    echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+    ```
+
+    Verify: `nix flake --help >/dev/null 2>&1 && echo "Flakes enabled"`
+  - "**A Linux or macOS machine.** The program runs headless via `QT_QPA_PLATFORM=offscreen`, so no display is required."
+
+sections:
+  - title: "How embedding liblogos works"
+    text: |
+      Your program links `liblogos_core` and calls its C API. The runtime loads
+      each module in an isolated subprocess that it launches through a separate
+      `logos_host` binary, and talks to it over the Logos IPC bridge:
+
+      Everything below comes from the liblogos commit under test: the
+      `liblogos_core` you link, the `logos_host` that hosts the module, and the
+      `logos_core.h` header you compile against.
+
+  - title: "Build liblogos from this commit"
+    step: true
+    text: |
+      Build the combined `logos-liblogos` package and symlink it to `./liblogos`.
+      The result contains everything an embedder needs: the C-API library, the
+      header, and the `logos_host` binary.
+
+      > The URL carries a release placeholder that pins the build to a specific
+      > commit: the doc-test runner expands it to a concrete ref. Locally that is
+      > this checkout's `HEAD` (see `run.sh`); in CI it is the commit being
+      > tested. With no pin it falls back to the latest `master`.
+    steps:
+      - title: "Build the library"
+        run: "nix build 'github:logos-co/logos-liblogos{release}' -o ./liblogos"
+        check_file: "liblogos/include/logos_core.h"
+        post_text: |
+          The result has three things your program depends on:
+
+          - `liblogos/include/logos_core.h` — the C API you compile against
+          - `liblogos/lib/liblogos_core.{ext}` — the shared library you link
+          - `liblogos/bin/logos_host` — the subprocess host the runtime launches
+            to run each module
+
+      - title: "Confirm the library, header, and host binary are present"
+        run: "ls liblogos/include/logos_core.h liblogos/lib/liblogos_core.{ext} liblogos/bin/logos_host"
+        check_file: "liblogos/lib/liblogos_core.{ext}"
+
+  - title: "Build lgpm and the modules to load"
+    step: true
+    text: |
+      The runtime discovers modules from a directory of installed packages. We
+      build the `lgpm` package manager and two real modules' `.lgx` packages,
+      then install them in the next step. `accounts_module` is loaded through the
+      host's capability layer, so we install `capability_module` alongside it.
+    steps:
+      - title: "Build lgpm"
+        run: "nix build 'github:logos-co/logos-package-manager#cli' -o lgpm"
+        check_file: "lgpm/bin/lgpm"
+        post_text: "The executable is at `./lgpm/bin/lgpm`."
+
+      - title: "Build the capability module's .lgx"
+        run: "nix build 'github:logos-co/logos-capability-module#lgx' -o cap-lgx"
+        post_text: "The `.lgx` package is under `./cap-lgx/`:"
+        extra_run:
+          run: "ls cap-lgx/*.lgx"
+
+      - title: "Build the accounts module's .lgx"
+        text: |
+          This compiles the module and its SDK dependencies through Nix (the
+          accounts module wraps the go-wallet-sdk C library), so the first build
+          is slow.
+        run: "nix build 'github:logos-co/logos-accounts-module#lgx' -o accounts-lgx"
+        post_text: "The `.lgx` package is under `./accounts-lgx/`:"
+        extra_run:
+          run: "ls accounts-lgx/*.lgx"
+
+  - title: "Install the modules with lgpm"
+    step: true
+    text: |
+      Install both packages into a local `./modules` directory. Installing through
+      `lgpm` writes each module's `manifest.json` with `"type": "core"`, which is
+      what makes the runtime discover them at startup. Both are unsigned local dev
+      builds, so we pass `--allow-unsigned`.
+    steps:
+      - title: "Install capability_module"
+        run: "./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file cap-lgx/*.lgx"
+        expect_contains:
+          - "Installed to:"
+
+      - title: "Install accounts_module"
+        run: "./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file accounts-lgx/*.lgx"
+        expect_contains:
+          - "Installed to:"
+
+      - title: "Confirm both modules are installed"
+        run: "./lgpm/bin/lgpm --modules-dir ./modules list"
+        expect_contains:
+          - "accounts_module"
+          - "capability_module"
+          - "core"
+        check_file: "modules/accounts_module/manifest.json"
+        post_text: |
+          Both modules now report type `core`, so `logos_core_start()` will
+          discover them.
+
+  - title: "Write the embedding program"
+    step: true
+    text: |
+      Now the program itself. It is plain C++ that links `liblogos_core` and
+      drives the C API. Two files: the source and a `CMakeLists.txt`.
+    steps:
+      - title: "src/main.cpp"
+        text: |
+          The whole lifecycle in one `main()`:
+
+          - Construct a `QCoreApplication` (liblogos uses Qt internally), but
+            never call `app.exec()` — the load calls are synchronous.
+          - Resolve the modules directory to an absolute path (`logos_core`
+            cannot read plugin metadata from a relative path).
+          - `logos_core_init` → `logos_core_add_modules_dir` → `logos_core_start`
+            (this discovers modules and brings up `capability_module`).
+          - `logos_core_load_module(name, true)` loads the requested module and
+            its dependencies; the module list accessors confirm what is up.
+        file:
+          path: embed-app/src/main.cpp
+          language: cpp
+          content: |
+            // Embedding the Logos runtime (liblogos_core) in your own program.
+            //
+            // liblogos exposes a C API in <logos_core.h>. Internally the runtime
+            // is built on Qt (it uses QPluginLoader to read module metadata and
+            // Qt's IPC stack to talk to modules), so an application that embeds
+            // it must construct a QCoreApplication before driving the C API. You
+            // do NOT need to run Qt's event loop: the load API below is
+            // synchronous. Module subprocesses are launched through a separate
+            // `logos_host` binary, located via the LOGOS_HOST_PATH environment
+            // variable.
+            #include <QCoreApplication>
+            #include "logos_core.h"
+
+            #include <cstdio>
+            #include <filesystem>
+
+            static void printList(const char* label, char** items) {
+                printf("%s:", label);
+                if (!items || !items[0]) { printf(" (none)\n"); return; }
+                printf("\n");
+                for (int i = 0; items[i]; ++i)
+                    printf("  - %s\n", items[i]);
+            }
+
+            int main(int argc, char** argv) {
+                setvbuf(stdout, nullptr, _IONBF, 0);
+
+                const char* modulesArg = (argc > 1) ? argv[1] : "./modules";
+                const char* moduleName = (argc > 2) ? argv[2] : "accounts_module";
+
+                // logos_core needs an absolute modules directory: it cannot read
+                // plugin metadata from a relative path. Resolve it up front.
+                const std::string modulesDir =
+                    std::filesystem::absolute(modulesArg).string();
+
+                // liblogos uses Qt internally, so a QCoreApplication must exist
+                // before we start the runtime. We never call app.exec(): the
+                // calls below are synchronous.
+                QCoreApplication app(argc, argv);
+
+                printf("Initializing Logos runtime...\n");
+                logos_core_init(argc, argv);
+                logos_core_add_modules_dir(modulesDir.c_str());
+
+                printf("Starting (modules dir: %s)\n", modulesDir.c_str());
+                logos_core_start();
+                printList("Discovered modules", logos_core_get_known_modules());
+
+                printf("Loading '%s' (with dependencies)...\n", moduleName);
+                int ok = logos_core_load_module(moduleName, /*with_dependencies=*/true);
+                printf("Load %s\n", ok ? "OK" : "FAILED");
+                printList("Loaded modules", logos_core_get_loaded_modules());
+
+                logos_core_cleanup();
+                return ok ? 0 : 1;
+            }
+
+      - title: "CMakeLists.txt"
+        text: |
+          A minimal build: find Qt6 Core, find `liblogos_core` under
+          `LOGOS_LIBLOGOS_ROOT` (the `nix build` result), and link both. The
+          `BUILD_RPATH` lets the program find `liblogos_core.{ext}` at runtime
+          without setting `LD_LIBRARY_PATH`.
+        file:
+          path: embed-app/CMakeLists.txt
+          language: cmake
+          content: |
+            cmake_minimum_required(VERSION 3.16)
+            project(logos_embed_app LANGUAGES CXX)
+
+            set(CMAKE_CXX_STANDARD 17)
+            set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+            # liblogos is built on Qt; an embedding program needs Qt Core too.
+            find_package(Qt6 REQUIRED COMPONENTS Core)
+
+            # Point this at the `nix build` result of logos-liblogos
+            # (it has bin/, lib/, and include/). Defaults to ../liblogos.
+            if(NOT DEFINED LOGOS_LIBLOGOS_ROOT)
+                set(LOGOS_LIBLOGOS_ROOT "${CMAKE_SOURCE_DIR}/../liblogos")
+            endif()
+            get_filename_component(LOGOS_LIBLOGOS_ROOT "${LOGOS_LIBLOGOS_ROOT}" ABSOLUTE)
+
+            find_library(LOGOS_CORE_LIBRARY NAMES logos_core
+                PATHS "${LOGOS_LIBLOGOS_ROOT}/lib" NO_DEFAULT_PATH REQUIRED)
+
+            add_executable(logos_embed_app src/main.cpp)
+            target_include_directories(logos_embed_app PRIVATE
+                "${LOGOS_LIBLOGOS_ROOT}/include")
+            target_link_libraries(logos_embed_app PRIVATE
+                ${LOGOS_CORE_LIBRARY} Qt6::Core)
+
+            # Find liblogos_core.{so,dylib} at runtime without LD_LIBRARY_PATH.
+            set_target_properties(logos_embed_app PROPERTIES
+                BUILD_RPATH "${LOGOS_LIBLOGOS_ROOT}/lib")
+
+  - title: "Build the program against this liblogos"
+    step: true
+    text: |
+      Build the program with CMake. We run the build **inside this liblogos'
+      dev shell** (`nix develop`) so the compiler and Qt version exactly match
+      the library you are linking — mismatched Qt is the most common cause of
+      embedding failures.
+    steps:
+      - title: "Configure and build"
+        run: "nix develop 'github:logos-co/logos-liblogos{release}' -c bash -c 'cd embed-app && cmake -S . -B build -G Ninja -DLOGOS_LIBLOGOS_ROOT=$PWD/../liblogos && cmake --build build'"
+        code_block: |
+          # Enter the liblogos dev shell (cmake, ninja, pkg-config, Qt6), then:
+          cd embed-app
+          cmake -S . -B build -G Ninja -DLOGOS_LIBLOGOS_ROOT="$PWD/../liblogos"
+          cmake --build build
+        check_file: "embed-app/build/logos_embed_app"
+        post_text: |
+          The program is at `embed-app/build/logos_embed_app`. Its `BUILD_RPATH`
+          points at `liblogos/lib`, so it runs without `LD_LIBRARY_PATH`.
+
+  - title: "Run it against the real module"
+    step: true
+    text: |
+      Run the program. It needs two things in the environment:
+
+      - `LOGOS_HOST_PATH` — the `logos_host` binary the runtime launches per
+        module (here, the one from the library we built).
+      - `QT_QPA_PLATFORM=offscreen` — so Qt needs no display.
+
+      We point it at `./modules` and ask it to load `accounts_module`.
+    steps:
+      - title: "Load accounts_module through the C API"
+        run: |
+          LOGOS_HOST_PATH="$PWD/liblogos/bin/logos_host" \
+          QT_QPA_PLATFORM=offscreen \
+            ./embed-app/build/logos_embed_app ./modules accounts_module
+        code_block: |
+          export LOGOS_HOST_PATH="$PWD/liblogos/bin/logos_host"
+          export QT_QPA_PLATFORM=offscreen
+          ./embed-app/build/logos_embed_app ./modules accounts_module
+        expect_contains:
+          - "Module loaded: capability_module"
+          - "Module loaded: accounts_module"
+          - "Load OK"
+        post_text: |
+          The output shows the runtime starting, discovering both modules,
+          bringing up `capability_module`, then loading `accounts_module` (a real
+          subprocess launched via `logos_host` and wired up over liblogos' IPC):
+
+          ```
+          Initializing Logos runtime...
+          Starting (modules dir: .../modules)
+          Module loaded: capability_module
+          Discovered modules:
+            - capability_module
+            - accounts_module
+          Loading 'accounts_module' (with dependencies)...
+          Module loaded: accounts_module
+          Load OK
+          Loaded modules:
+            - capability_module
+            - accounts_module
+          ```
+
+          That is your own program — not the `logoscore` CLI — running a real
+          module on top of this liblogos.
+
+  - title: "Inspect the module's API"
+    step: true
+    text: |
+      The C API loads and manages modules; it does not call their methods (that
+      goes over the typed IPC bridge, which the frontends wrap). To see what
+      `accounts_module` exposes, introspect the installed plugin with `lm`, the
+      module inspector from [`logos-module`](https://github.com/logos-co/logos-module).
+    steps:
+      - title: "Build lm"
+        run: "nix build 'github:logos-co/logos-module#lm' -o lm"
+        check_file: "lm/bin/lm"
+
+      - title: "List the module's invokable methods"
+        run: "./lm/bin/lm methods ./modules/accounts_module/accounts_module_plugin.{ext}"
+        code_block: "lm methods ./modules/accounts_module/accounts_module_plugin.{ext}"
+        expect_contains:
+          - "createRandomMnemonic"
+        post_text: |
+          These are the `Q_INVOKABLE` methods the module you just loaded exposes —
+          the entry points a frontend would call over the IPC bridge once the
+          module is up.

--- a/doctests/outputs/liblogos-as-a-library.md
+++ b/doctests/outputs/liblogos-as-a-library.md
@@ -1,0 +1,379 @@
+# Embedding This liblogos as a Library
+
+# WARNING
+  ** IMPORTANT **
+  This doctest is for internal dev purposes and should not be used. It displays important flaws that will be corrected, specifically that QCoreApplication should no longer be needed but it's pending some changes still at which point this doctest will be updated to reflect that
+  ** IMPORTANT **
+`logos-liblogos` is a **library**. The headless `logoscore` CLI and the
+basecamp desktop app are just frontends for it — each one links
+`liblogos_core` and drives its C API (`logos_core.h`) to discover, load, and
+manage modules. This doc-test shows how to do the same thing in **your own
+program**, built against **this** liblogos commit:
+
+1. Build `liblogos_core` (the C-API shared library), its `logos_host`
+   subprocess binary, and the `logos_core.h` header — all from the commit
+   under test.
+2. Build the `lgpm` package manager and install two real modules
+   ([`capability_module`](https://github.com/logos-co/logos-capability-module)
+   and [`accounts_module`](https://github.com/logos-co/logos-accounts-module))
+   into a local modules directory.
+3. Write a ~50-line C++ program that links `liblogos_core`, then calls the C
+   API to start the runtime and load `accounts_module`.
+4. Build that program against this liblogos and run it — watching the module
+   come up over liblogos' own IPC.
+
+Because the library, the host binary, and the headers all come from the commit
+under test, a green run is direct evidence that **this** liblogos is usable as
+an embeddable library, not just through the `logoscore` frontend.
+
+> **Why C++ and not pure C?** The API in `logos_core.h` is plain C, but the
+> runtime is built on Qt internally (it uses `QPluginLoader` to read module
+> metadata and Qt's IPC stack to talk to modules). So an embedding program must
+> construct a `QCoreApplication` before it calls `logos_core_start()` — exactly
+> as `logoscore` and basecamp do. You do **not** need to run Qt's event loop;
+> the load calls are synchronous.
+
+**What you'll build:** A standalone C++ program that links `liblogos_core` from this commit and loads the real `accounts_module` through the C API.
+
+**What you'll learn:**
+
+- How to build `liblogos_core`, `logos_host`, and `logos_core.h` from a specific liblogos commit
+- What a minimal `CMakeLists.txt` that links `liblogos_core` looks like
+- The lifecycle of the C API: `logos_core_init` → `add_modules_dir` → `start` → `load_module` → `cleanup`
+- Why an embedding program needs a `QCoreApplication`, and where `logos_host` fits in (`LOGOS_HOST_PATH`)
+- How to install modules with `lgpm` so the runtime can discover them
+
+## Prerequisites
+
+- **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then enable flakes:
+
+```bash
+mkdir -p ~/.config/nix
+echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+```
+
+Verify: `nix flake --help >/dev/null 2>&1 && echo "Flakes enabled"`
+
+- **A Linux or macOS machine.** The program runs headless via `QT_QPA_PLATFORM=offscreen`, so no display is required.
+
+---
+
+## How embedding liblogos works
+
+Your program links `liblogos_core` and calls its C API. The runtime loads
+each module in an isolated subprocess that it launches through a separate
+`logos_host` binary, and talks to it over the Logos IPC bridge:
+
+Everything below comes from the liblogos commit under test: the
+`liblogos_core` you link, the `logos_host` that hosts the module, and the
+`logos_core.h` header you compile against.
+
+## Step 1: Build liblogos from this commit
+
+Build the combined `logos-liblogos` package and symlink it to `./liblogos`.
+The result contains everything an embedder needs: the C-API library, the
+header, and the `logos_host` binary.
+
+> The URL carries a release placeholder that pins the build to a specific
+> commit: the doc-test runner expands it to a concrete ref. Locally that is
+> this checkout's `HEAD` (see `run.sh`); in CI it is the commit being
+> tested. With no pin it falls back to the latest `master`.
+
+### 1.1 Build the library
+
+```bash
+nix build 'github:logos-co/logos-liblogos/5f8139723702a8fff7eee6ae20c042be1c72159f' -o ./liblogos
+```
+
+The result has three things your program depends on:
+
+- `liblogos/include/logos_core.h` — the C API you compile against
+- `liblogos/lib/liblogos_core.dylib` — the shared library you link
+- `liblogos/bin/logos_host` — the subprocess host the runtime launches
+  to run each module
+
+### 1.2 Confirm the library, header, and host binary are present
+
+```bash
+ls liblogos/include/logos_core.h liblogos/lib/liblogos_core.dylib liblogos/bin/logos_host
+```
+
+---
+
+## Step 2: Build lgpm and the modules to load
+
+The runtime discovers modules from a directory of installed packages. We
+build the `lgpm` package manager and two real modules' `.lgx` packages,
+then install them in the next step. `accounts_module` is loaded through the
+host's capability layer, so we install `capability_module` alongside it.
+
+### 2.1 Build lgpm
+
+```bash
+nix build 'github:logos-co/logos-package-manager#cli' -o lgpm
+```
+
+The executable is at `./lgpm/bin/lgpm`.
+
+### 2.2 Build the capability module's .lgx
+
+```bash
+nix build 'github:logos-co/logos-capability-module#lgx' -o cap-lgx
+```
+
+The `.lgx` package is under `./cap-lgx/`:
+
+```bash
+ls cap-lgx/*.lgx
+```
+
+### 2.3 Build the accounts module's .lgx
+
+This compiles the module and its SDK dependencies through Nix (the
+accounts module wraps the go-wallet-sdk C library), so the first build
+is slow.
+
+```bash
+nix build 'github:logos-co/logos-accounts-module#lgx' -o accounts-lgx
+```
+
+The `.lgx` package is under `./accounts-lgx/`:
+
+```bash
+ls accounts-lgx/*.lgx
+```
+
+---
+
+## Step 3: Install the modules with lgpm
+
+Install both packages into a local `./modules` directory. Installing through
+`lgpm` writes each module's `manifest.json` with `"type": "core"`, which is
+what makes the runtime discover them at startup. Both are unsigned local dev
+builds, so we pass `--allow-unsigned`.
+
+### 3.1 Install capability_module
+
+```bash
+./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file cap-lgx/*.lgx
+```
+
+### 3.2 Install accounts_module
+
+```bash
+./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file accounts-lgx/*.lgx
+```
+
+### 3.3 Confirm both modules are installed
+
+```bash
+./lgpm/bin/lgpm --modules-dir ./modules list
+```
+
+Both modules now report type `core`, so `logos_core_start()` will
+discover them.
+
+---
+
+## Step 4: Write the embedding program
+
+Now the program itself. It is plain C++ that links `liblogos_core` and
+drives the C API. Two files: the source and a `CMakeLists.txt`.
+
+### 4.1 src/main.cpp
+
+The whole lifecycle in one `main()`:
+
+- Construct a `QCoreApplication` (liblogos uses Qt internally), but
+  never call `app.exec()` — the load calls are synchronous.
+- Resolve the modules directory to an absolute path (`logos_core`
+  cannot read plugin metadata from a relative path).
+- `logos_core_init` → `logos_core_add_modules_dir` → `logos_core_start`
+  (this discovers modules and brings up `capability_module`).
+- `logos_core_load_module(name, true)` loads the requested module and
+  its dependencies; the module list accessors confirm what is up.
+
+```cpp
+// Embedding the Logos runtime (liblogos_core) in your own program.
+//
+// liblogos exposes a C API in <logos_core.h>. Internally the runtime
+// is built on Qt (it uses QPluginLoader to read module metadata and
+// Qt's IPC stack to talk to modules), so an application that embeds
+// it must construct a QCoreApplication before driving the C API. You
+// do NOT need to run Qt's event loop: the load API below is
+// synchronous. Module subprocesses are launched through a separate
+// `logos_host` binary, located via the LOGOS_HOST_PATH environment
+// variable.
+#include <QCoreApplication>
+#include "logos_core.h"
+
+#include <cstdio>
+#include <filesystem>
+
+static void printList(const char* label, char** items) {
+    printf("%s:", label);
+    if (!items || !items[0]) { printf(" (none)\n"); return; }
+    printf("\n");
+    for (int i = 0; items[i]; ++i)
+        printf("  - %s\n", items[i]);
+}
+
+int main(int argc, char** argv) {
+    setvbuf(stdout, nullptr, _IONBF, 0);
+
+    const char* modulesArg = (argc > 1) ? argv[1] : "./modules";
+    const char* moduleName = (argc > 2) ? argv[2] : "accounts_module";
+
+    // logos_core needs an absolute modules directory: it cannot read
+    // plugin metadata from a relative path. Resolve it up front.
+    const std::string modulesDir =
+        std::filesystem::absolute(modulesArg).string();
+
+    // liblogos uses Qt internally, so a QCoreApplication must exist
+    // before we start the runtime. We never call app.exec(): the
+    // calls below are synchronous.
+    QCoreApplication app(argc, argv);
+
+    printf("Initializing Logos runtime...\n");
+    logos_core_init(argc, argv);
+    logos_core_add_modules_dir(modulesDir.c_str());
+
+    printf("Starting (modules dir: %s)\n", modulesDir.c_str());
+    logos_core_start();
+    printList("Discovered modules", logos_core_get_known_modules());
+
+    printf("Loading '%s' (with dependencies)...\n", moduleName);
+    int ok = logos_core_load_module(moduleName, /*with_dependencies=*/true);
+    printf("Load %s\n", ok ? "OK" : "FAILED");
+    printList("Loaded modules", logos_core_get_loaded_modules());
+
+    logos_core_cleanup();
+    return ok ? 0 : 1;
+}
+```
+
+### 4.2 CMakeLists.txt
+
+A minimal build: find Qt6 Core, find `liblogos_core` under
+`LOGOS_LIBLOGOS_ROOT` (the `nix build` result), and link both. The
+`BUILD_RPATH` lets the program find `liblogos_core.dylib` at runtime
+without setting `LD_LIBRARY_PATH`.
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(logos_embed_app LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# liblogos is built on Qt; an embedding program needs Qt Core too.
+find_package(Qt6 REQUIRED COMPONENTS Core)
+
+# Point this at the `nix build` result of logos-liblogos
+# (it has bin/, lib/, and include/). Defaults to ../liblogos.
+if(NOT DEFINED LOGOS_LIBLOGOS_ROOT)
+    set(LOGOS_LIBLOGOS_ROOT "${CMAKE_SOURCE_DIR}/../liblogos")
+endif()
+get_filename_component(LOGOS_LIBLOGOS_ROOT "${LOGOS_LIBLOGOS_ROOT}" ABSOLUTE)
+
+find_library(LOGOS_CORE_LIBRARY NAMES logos_core
+    PATHS "${LOGOS_LIBLOGOS_ROOT}/lib" NO_DEFAULT_PATH REQUIRED)
+
+add_executable(logos_embed_app src/main.cpp)
+target_include_directories(logos_embed_app PRIVATE
+    "${LOGOS_LIBLOGOS_ROOT}/include")
+target_link_libraries(logos_embed_app PRIVATE
+    ${LOGOS_CORE_LIBRARY} Qt6::Core)
+
+# Find liblogos_core.{so,dylib} at runtime without LD_LIBRARY_PATH.
+set_target_properties(logos_embed_app PROPERTIES
+    BUILD_RPATH "${LOGOS_LIBLOGOS_ROOT}/lib")
+```
+
+---
+
+## Step 5: Build the program against this liblogos
+
+Build the program with CMake. We run the build **inside this liblogos'
+dev shell** (`nix develop`) so the compiler and Qt version exactly match
+the library you are linking — mismatched Qt is the most common cause of
+embedding failures.
+
+### 5.1 Configure and build
+
+```bash
+# Enter the liblogos dev shell (cmake, ninja, pkg-config, Qt6), then:
+cd embed-app
+cmake -S . -B build -G Ninja -DLOGOS_LIBLOGOS_ROOT="$PWD/../liblogos"
+cmake --build build
+```
+
+The program is at `embed-app/build/logos_embed_app`. Its `BUILD_RPATH`
+points at `liblogos/lib`, so it runs without `LD_LIBRARY_PATH`.
+
+---
+
+## Step 6: Run it against the real module
+
+Run the program. It needs two things in the environment:
+
+- `LOGOS_HOST_PATH` — the `logos_host` binary the runtime launches per
+  module (here, the one from the library we built).
+- `QT_QPA_PLATFORM=offscreen` — so Qt needs no display.
+
+We point it at `./modules` and ask it to load `accounts_module`.
+
+### 6.1 Load accounts_module through the C API
+
+```bash
+export LOGOS_HOST_PATH="$PWD/liblogos/bin/logos_host"
+export QT_QPA_PLATFORM=offscreen
+./embed-app/build/logos_embed_app ./modules accounts_module
+```
+
+The output shows the runtime starting, discovering both modules,
+bringing up `capability_module`, then loading `accounts_module` (a real
+subprocess launched via `logos_host` and wired up over liblogos' IPC):
+
+```
+Initializing Logos runtime...
+Starting (modules dir: .../modules)
+Module loaded: capability_module
+Discovered modules:
+  - capability_module
+  - accounts_module
+Loading 'accounts_module' (with dependencies)...
+Module loaded: accounts_module
+Load OK
+Loaded modules:
+  - capability_module
+  - accounts_module
+```
+
+That is your own program — not the `logoscore` CLI — running a real
+module on top of this liblogos.
+
+---
+
+## Step 7: Inspect the module's API
+
+The C API loads and manages modules; it does not call their methods (that
+goes over the typed IPC bridge, which the frontends wrap). To see what
+`accounts_module` exposes, introspect the installed plugin with `lm`, the
+module inspector from [`logos-module`](https://github.com/logos-co/logos-module).
+
+### 7.1 Build lm
+
+```bash
+nix build 'github:logos-co/logos-module#lm' -o lm
+```
+
+### 7.2 List the module's invokable methods
+
+```bash
+lm methods ./modules/accounts_module/accounts_module_plugin.dylib
+```
+
+These are the `Q_INVOKABLE` methods the module you just loaded exposes —
+the entry points a frontend would call over the IPC bridge once the
+module is up.

--- a/doctests/outputs/liblogos-module-runtime.md
+++ b/doctests/outputs/liblogos-module-runtime.md
@@ -59,7 +59,7 @@ than the latest release. The result is symlinked to `./logos/`.
 ### 1.1 Build the CLI with the liblogos override
 
 ```bash
-nix build 'github:logos-co/logos-logoscore-cli' \
+nix build 'github:logos-co/logos-logoscore-cli/b92ade06cdbd3cdf48c8de5b8375cbcc3a6088cf' \
   --override-input logos-liblogos 'github:logos-co/logos-liblogos' \
   --out-link ./logos
 ```

--- a/doctests/run.sh
+++ b/doctests/run.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 #
-# Execute the liblogos module-runtime doc-test end-to-end and regenerate its
-# Markdown.
+# Execute the liblogos doc-tests end-to-end and regenerate their Markdown.
+#
+# Two specs run, each exercising THIS liblogos commit a different way:
+#   - liblogos-module-runtime.test.yaml — drives liblogos through the headless
+#     `logoscore` CLI frontend (build logoscore against this liblogos, install
+#     the accounts module, start the daemon, call methods).
+#   - liblogos-as-a-library.test.yaml — embeds liblogos directly: builds
+#     liblogos_core from this commit, compiles a small C++ program that links it,
+#     installs modules with lgpm, and loads the accounts module through the C API.
 #
 # The runner is the shared `doctest` CLI
 # (https://github.com/logos-co/logos-doctest), invoked directly via its flake.
-# `doctest run` executes every command in a temp directory (building logoscore
-# against this liblogos, building lgpm, packaging/installing the accounts
-# module, starting the daemon, calling methods) and asserts on the output;
-# `doctest generate` renders the same spec to Markdown under outputs/;
+# `doctest run` executes every command in a temp directory and asserts on the
+# output; `doctest generate` renders the same spec to Markdown under outputs/;
 # `doctest clean` strips build artifacts so only the generated docs remain.
 #
 # To run against a local logos-doctest checkout instead of the published flake,
@@ -22,7 +27,12 @@ cd "$(dirname "$0")"
 # The doctest CLI. Override by exporting DOCTEST (space-separated command).
 read -r -a DOCTEST <<< "${DOCTEST:-nix run github:logos-co/logos-doctest --}"
 OUTPUT_DIR="./outputs"
-SPEC="liblogos-module-runtime.test.yaml"
+# Specs to run. Each renders to outputs/<its `output:` filename>.md; its
+# disposable run artifacts go in a per-spec subdir so the two don't collide.
+SPECS=(
+  "liblogos-module-runtime.test.yaml"
+  "liblogos-as-a-library.test.yaml"
+)
 
 # Build the doc-test against THIS repo's current commit rather than the latest
 # published flake. The spec overrides logoscore's `logos-liblogos` input with
@@ -51,21 +61,33 @@ if [ -e "${OUTPUT_DIR}" ]; then
   chmod -R u+w "${OUTPUT_DIR}" 2>/dev/null || true
 fi
 rm -rf "${OUTPUT_DIR}"
-
-echo "==> Running ${SPEC} into ${OUTPUT_DIR}/"
-# ${RELEASE_FOR[@]+...} guards the expansion so an empty array doesn't trip
-# `set -u` on older bash (e.g. macOS's stock 3.2).
-"${DOCTEST[@]}" run "${SPEC}" \
-  --verbose \
-  --continue-on-fail \
-  ${RELEASE_FOR[@]+"${RELEASE_FOR[@]}"} \
-  --output-dir "${OUTPUT_DIR}/"
-
-echo "==> Generating ${OUTPUT_DIR}/liblogos-module-runtime.md"
 mkdir -p "${OUTPUT_DIR}"
-"${DOCTEST[@]}" generate "${SPEC}" \
-  ${RELEASE_FOR[@]+"${RELEASE_FOR[@]}"} \
-  -o "${OUTPUT_DIR}/liblogos-module-runtime.md"
+
+# Read the `output:` filename a spec renders to (e.g. "foo.md") from its YAML.
+spec_output() {
+  sed -n 's/^output:[[:space:]]*//p' "$1" | head -n1 | tr -d '"'
+}
+
+for SPEC in "${SPECS[@]}"; do
+  STEM="${SPEC%.test.yaml}"
+  MD="$(spec_output "${SPEC}")"
+  : "${MD:=${STEM}.md}"
+  SPEC_OUT="${OUTPUT_DIR}/${STEM}"
+
+  echo "==> Running ${SPEC} into ${SPEC_OUT}/"
+  # ${RELEASE_FOR[@]+...} guards the expansion so an empty array doesn't trip
+  # `set -u` on older bash (e.g. macOS's stock 3.2).
+  "${DOCTEST[@]}" run "${SPEC}" \
+    --verbose \
+    --continue-on-fail \
+    ${RELEASE_FOR[@]+"${RELEASE_FOR[@]}"} \
+    --output-dir "${SPEC_OUT}/"
+
+  echo "==> Generating ${OUTPUT_DIR}/${MD}"
+  "${DOCTEST[@]}" generate "${SPEC}" \
+    ${RELEASE_FOR[@]+"${RELEASE_FOR[@]}"} \
+    -o "${OUTPUT_DIR}/${MD}"
+done
 
 if [ ! -d "${OUTPUT_DIR}" ]; then
   echo "==> No ${OUTPUT_DIR}/ produced; nothing to clean."
@@ -75,4 +97,4 @@ fi
 echo "==> Cleaning build artifacts from ${OUTPUT_DIR}/"
 "${DOCTEST[@]}" clean "${OUTPUT_DIR}" --verbose
 
-echo "==> Done. Rendered doc is in ${OUTPUT_DIR}/liblogos-module-runtime.md"
+echo "==> Done. Rendered docs are in ${OUTPUT_DIR}/."


### PR DESCRIPTION
This doctest is for internal dev purposes and should not be used. It displays important flaws that will be corrected, specifically that QCoreApplication should no longer be needed but it's pending some changes still at which point this doctest will be updated to reflect that