### PR TITLE
deps: bump logos-module-loader-qt to the process-group isolation fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781734000,
-        "narHash": "sha256-TyrUHKnb5llx+Z5GN+bMAbjkxON6w7aj4yN6gokq2eQ=",
+        "lastModified": 1781741734,
+        "narHash": "sha256-GHyeMvVho8AWDeWb8cKQQLU0dIM0ynsnrJkvS2Q6Ihs=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "08213eb216ae9b33c73830d3cf2d9111d97cbbcb",
+        "rev": "331760de70938e98a8756aaf2cdbe99e763376f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Bumps the `default-module-loader` input (logos-module-loader-qt) **`08213eb` → `331760d`**.

## Why

The host binary was extracted out of liblogos into [`logos-module-loader-qt`](https://github.com/logos-co/logos-module-loader-qt) (#149/#151/#152). That extraction pinned `08213eb`, a host **without** the subprocess process-group isolation + parent-death cleanup — the `setsid()` + `PR_SET_PDEATHSIG` + `getppid` watchdog that previously lived on the pre-refactor `272c6b5` lineage of liblogos.

logos-module-loader-qt **#3 (`331760d`)** forward-ports that exact fix into the extracted host (`src/host/logos_host.cpp`, **+50 lines, no interface change**). This bump pulls it in, so liblogos `master` once again ships a host that:
- leads its own process group (`setsid`/`setpgid`), so daemon-group signals don't leak into the launcher, and
- exits when its parent daemon dies (`PR_SET_PDEATHSIG` + portable `getppid` watchdog), so a crashed daemon doesn't leak `logos_host` workers.

## Effect

Downstream consumers (logoscore-cli, basecamp) can now track liblogos `master` and keep the isolation behavior, instead of pinning the pre-refactor `272c6b5` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)