### PR TITLE
fix(tests): avoid core boot during gtest discovery timeout

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,4 +82,4 @@ if(DEFINED LOGOS_PROTOCOL_ROOT AND EXISTS "${LOGOS_PROTOCOL_ROOT}/include")
   )
 endif()
 
-gtest_discover_tests(logos_core_tests)
+gtest_discover_tests(logos_core_tests DISCOVERY_MODE PRE_TEST)

--- a/tests/test_app_lifecycle.cpp
+++ b/tests/test_app_lifecycle.cpp
@@ -14,7 +14,9 @@ int main(int argc, char** argv) {
     // When only listing tests (e.g. POST_BUILD test discovery), don't boot the
     // full core — just enumerate. Booting Qt/subprocess/IOKit here can blow past
     // the test-discovery timeout in sandboxed builds.
-    if (::testing::GTEST_FLAG(list_tests)) {
+    // GTEST_FLAG_GET already qualifies with ::testing:: internally and works
+    // with both the Abseil and non-Abseil gtest flag backends — do not prefix it.
+    if (GTEST_FLAG_GET(list_tests)) {
         return RUN_ALL_TESTS();
     }
     logos_core_init(argc, argv);

--- a/tests/test_app_lifecycle.cpp
+++ b/tests/test_app_lifecycle.cpp
@@ -10,8 +10,14 @@ static void clearModuleState() {
 }
 
 int main(int argc, char** argv) {
-    logos_core_init(argc, argv);
     ::testing::InitGoogleTest(&argc, argv);
+    // When only listing tests (e.g. POST_BUILD test discovery), don't boot the
+    // full core — just enumerate. Booting Qt/subprocess/IOKit here can blow past
+    // the test-discovery timeout in sandboxed builds.
+    if (::testing::GTEST_FLAG(list_tests)) {
+        return RUN_ALL_TESTS();
+    }
+    logos_core_init(argc, argv);
     int result = RUN_ALL_TESTS();
     logos_core_cleanup();
     return result;


### PR DESCRIPTION
## Problem

CI builds fail with a wall of `dependency failed` errors ending at `run-logos-standalone-ui`, but that's just the cascade — the real failure is inside `logos-liblogos`. The C++ compiles and links fine and all build steps pass; it dies one step later in CMake test discovery with `Process terminated due to timeout` and empty output. Deterministic (reproduces identically every run).

## Root cause

`tests/CMakeLists.txt` used `gtest_discover_tests(logos_core_tests)` with no options, so it defaulted to **POST_BUILD** discovery mode — which runs the freshly-built test binary with `--gtest_list_tests` at build time just to enumerate tests.

But `tests/test_app_lifecycle.cpp`'s `main()` called `logos_core_init(argc, argv)` **before** `::testing::InitGoogleTest()`:

```cpp
int main(int argc, char** argv) {
    logos_core_init(argc, argv);        // ran first, unconditionally
    ::testing::InitGoogleTest(&argc, argv);
    ...
}
```

So even when only listing tests, discovery booted the full Qt core (QCoreApplication + subprocess/socket/IOKit) and loaded the whole dylib closure (Qt, boost, openssl, package-manager). In the Nix sandbox that blows past the 5s `TEST_DISCOVERY_TIMEOUT`, the binary is killed with empty output, and the whole derivation fails.

## Fix (two parts)

1. **`tests/CMakeLists.txt`** — `gtest_discover_tests(logos_core_tests DISCOVERY_MODE PRE_TEST)`. Defers enumeration to `ctest` time so the binary never runs during the Nix build. This alone deterministically fixes the failure.
2. **`tests/test_app_lifecycle.cpp`** — run `InitGoogleTest` first and return early when only listing tests, before `logos_core_init()`. Correctness safety-net so listing never boots the core regardless of discovery mode.

## Validation

`ws test logos-liblogos --auto-local` → **PASS**. Sails past discovery; the full chain (lib → bin → standalone-app) builds green when pointed at this branch via `--override-input`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)