### PR TITLE
chore: bump logos-protocol to master (nested-bytes qvariantToNlohmann fix #23)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5071,11 +5071,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782490644,
-        "narHash": "sha256-IRHFIBa/+a10tVNEexm6DDZ0JPF8YQgUbxWoNwIytt4=",
+        "lastModified": 1784328026,
+        "narHash": "sha256-g+tR1Y/8b0yj28BWqybG8S9iDDTuwM8qs0FG8AuqoOU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "d5d58e7e230768505c683150f651358612abd442",
+        "rev": "d5ba950313b3e4bb9d42d97af4c28df9083cfb41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Re-pins `logos-protocol` → master `d5ba950`, pulling in [logos-protocol#23](https://github.com/logos-co/logos-protocol/pull/23).

This is the **key carrier for the host-side runtime fix**: the ModuleProxy that bridges a call to a cdylib module lives here, and it runs `qvariantToNlohmann` on the (container-valued) call arguments. Before #23 a nested `QByteArray` was flattened to a plain string, so a `bstr` argument reached a Rust cdylib as `"hello"` and decoded to an empty `Vec` (e.g. `echoBytes` returned `null`). After the bump the tag survives and the bytes round-trip.

`cpp-sdk`/`qt-sdk` inputs follow this protocol bump; builds clean locally. Downstream hosts (logoscore-cli, standalone-app, basecamp) will pin this re-pinned liblogos next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)