### PR TITLE
chore: re-pin logos-protocol to master (LogosAPIConsumer handle cache)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5071,11 +5071,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784328026,
-        "narHash": "sha256-g+tR1Y/8b0yj28BWqybG8S9iDDTuwM8qs0FG8AuqoOU=",
+        "lastModified": 1784512868,
+        "narHash": "sha256-URbriX1AnFRgP7ZmgINPkTPnvCNNilzLxnIhGa2Ot6M=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "d5ba950313b3e4bb9d42d97af4c28df9083cfb41",
+        "rev": "664b43f18a9e752c0a80a422e5edfd99d76ffef6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-protocol` to master (664b43f, logos-co/logos-protocol#24) — LogosAPIConsumer now caches the remote-object handle per name (sync + async), so logos_host/ui-host avoid a per-call QtRO replica acquire when a consumer drives one target repeatedly. qt-sdk/cpp-sdk follow logos-protocol, so this single bump threads it through. Consumer-side, ABI-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)