### PR TITLE
feat: auto-restart capability_module on unexpected exit

### DIFF
--- a/doctests/liblogos-capability-crash-recovery.test.yaml
+++ b/doctests/liblogos-capability-crash-recovery.test.yaml
@@ -1,0 +1,172 @@
+name: "Recovering From a capability_module Crash"
+output: liblogos-capability-crash-recovery.md
+release: ""
+
+intro: |
+  `capability_module` is the token authority the host loads first: every module
+  load and every cross-module call is brokered through it. If its subprocess
+  dies and nothing brings it back, all inter-module token exchange is dead until
+  the whole app restarts — which is exactly what happened in the field after a
+  mid-session module crash.
+
+  **This** liblogos commit adds a supervisor for that case. When
+  `capability_module`'s subprocess exits unexpectedly, liblogos detects it,
+  respawns the module, and re-teaches every loaded module's token — bounded by a
+  crash-loop circuit breaker so a module that crashes on every boot can't
+  fork-bomb.
+
+  This doc-test proves it end to end: it runs a real `logoscore` daemon on this
+  liblogos, loads a module, then **`kill -9`s `capability_module`'s subprocess**
+  and confirms the supervisor brings it straight back — no daemon restart.
+
+what_you_build: "A `logoscore` daemon on this liblogos with a module loaded, whose `capability_module` broker is killed mid-session and automatically respawned by the supervisor."
+
+what_you_learn:
+  - Why capability_module is a single point of failure for token exchange
+  - How the liblogos supervisor detects an unexpected capability_module exit and respawns it
+  - How to observe the recovery in the daemon log and confirm the module is loaded again
+
+prerequisites:
+  - |
+    **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then enable flakes:
+
+    ```bash
+    mkdir -p ~/.config/nix
+    echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+    ```
+
+    Verify: `nix flake --help >/dev/null 2>&1 && echo "Flakes enabled"`
+  - "**git** — to clone the module repository."
+  - "A Linux or macOS machine."
+
+sections:
+  - title: "Build logoscore against this liblogos"
+    step: true
+    text: |
+      Build the `logoscore` CLI from its published flake, **overriding its
+      `logos-liblogos` input** so the host, module loader, and — crucially — the
+      capability supervisor all come from the commit under test.
+    steps:
+      - title: "Build the CLI with the liblogos override"
+        run: "nix build 'github:logos-co/logos-logoscore-cli/b92ade06cdbd3cdf48c8de5b8375cbcc3a6088cf' --override-input logos-liblogos 'github:logos-co/logos-liblogos{release}' --out-link ./logos"
+        code_block: |
+          nix build 'github:logos-co/logos-logoscore-cli/b92ade06cdbd3cdf48c8de5b8375cbcc3a6088cf' \
+            --override-input logos-liblogos 'github:logos-co/logos-liblogos' \
+            --out-link ./logos
+        check_file: "logos/bin/logoscore"
+        post_text: |
+          The build produces `logos/bin/logoscore` plus a `logos/modules/`
+          directory with the built-in `capability_module`. `follows` propagates
+          the override, so the whole closure is rebuilt against this liblogos.
+
+  - title: "Build the lgpm package manager and a module"
+    step: true
+    text: |
+      We need one ordinary module loaded so the supervisor has a token to
+      re-teach on recovery. We reuse `accounts_module` — any module works.
+    steps:
+      - title: "Build lgpm"
+        run: "nix build 'github:logos-co/logos-package-manager#cli' -o lgpm"
+        check_file: "lgpm/bin/lgpm"
+
+      - title: "Clone and build the module's .lgx"
+        run: "git clone --depth 1 https://github.com/logos-co/logos-accounts-module.git"
+        check_file: "logos-accounts-module/flake.nix"
+
+      - title: "Build the .lgx"
+        run: "nix build 'path:./logos-accounts-module#lgx' -o accounts-lgx"
+        extra_run:
+          run: "ls accounts-lgx/*.lgx"
+
+      - title: "Seed the modules directory with the bundled capability module"
+        text: |
+          The modules directory needs the `capability_module` that ships with
+          `logoscore` (the broker) alongside the module we install.
+        run: |
+          mkdir -p modules
+          cp -RL ./logos/modules/. ./modules/
+        check_file: "modules/capability_module/manifest.json"
+
+      - title: "Install the module"
+        run: "./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file accounts-lgx/*.lgx"
+        expect_contains:
+          - "Installed to:"
+
+  - title: "Run the daemon and load a module"
+    step: true
+    text: |
+      Start the daemon, load `accounts_module` (its load is brokered by
+      `capability_module`), and confirm both are up. Daemon output goes to
+      `logs.txt`.
+    steps:
+      - title: "Start the daemon"
+        run: "sh -c './logos/bin/logoscore -D -m ./modules > logs.txt 2>&1 &'"
+        code_block: "logoscore -D -m ./modules > logs.txt &"
+
+      - run: "sleep 3"
+
+      - title: "capability_module and accounts_module are loaded"
+        run: "./logos/bin/logoscore load-module accounts_module && ./logos/bin/logoscore list-modules --loaded"
+        code_block: |
+          logoscore load-module accounts_module
+          logoscore list-modules --loaded
+        expect_contains:
+          - "capability_module"
+          - "accounts_module"
+
+  - title: "Crash capability_module and watch it recover"
+    step: true
+    text: |
+      Now simulate the failure: find `capability_module`'s subprocess and
+      `kill -9` it — an unrecoverable crash from the process's point of view. The
+      supervisor in this liblogos should detect the exit and respawn it.
+    steps:
+      - title: "Kill the capability_module subprocess"
+        text: |
+          Each module runs in its own `logos_host` subprocess. We match on the
+          plugin path so we hit `capability_module`'s host and not the daemon:
+        run: |
+          CAP_PID=$(pgrep -f 'capability_module_plugin' | head -1)
+          echo "capability_module subprocess PID: $CAP_PID"
+          kill -9 "$CAP_PID"
+        code_block: |
+          CAP_PID=$(pgrep -f 'capability_module_plugin' | head -1)
+          kill -9 "$CAP_PID"
+        expect_contains:
+          - "capability_module subprocess PID:"
+
+      - title: "Give the supervisor a moment"
+        run: "sleep 6"
+
+      - title: "The daemon log shows the supervisor recovering it"
+        text: |
+          The supervisor logs the crash, the restart attempt, and success —
+          re-provisioning `capability_module` and re-teaching the loaded modules'
+          tokens, all without restarting the daemon:
+        run: "grep -iE 'crashed|auto-restart' logs.txt"
+        expect_contains:
+          - "Module process crashed: capability_module"
+          - "capability_module exited unexpectedly — auto-restarting"
+          - "auto-restart succeeded; token exchange restored"
+
+      - title: "capability_module is loaded again"
+        text: |
+          Despite the `kill -9`, `capability_module` is back — a fresh subprocess,
+          brought up by the supervisor:
+        run: "./logos/bin/logoscore list-modules --loaded"
+        code_block: "logoscore list-modules --loaded"
+        expect_contains:
+          - "capability_module"
+
+      - title: "Token exchange still works — call the module"
+        text: |
+          A call through the daemon is still brokered end to end, confirming the
+          capability layer is live after the recovery:
+        run: "./logos/bin/logoscore call accounts_module createRandomMnemonic 12"
+        code_block: "logoscore call accounts_module createRandomMnemonic 12"
+        expect_contains:
+          - '"result"'
+
+      - title: "Stop the daemon"
+        run: "./logos/bin/logoscore stop"
+        code_block: "logoscore stop"

--- a/doctests/run.sh
+++ b/doctests/run.sh
@@ -32,6 +32,7 @@ OUTPUT_DIR="./outputs"
 SPECS=(
   "liblogos-module-runtime.test.yaml"
   "liblogos-as-a-library.test.yaml"
+  "liblogos-capability-crash-recovery.test.yaml"
 )
 
 # Build the doc-test against THIS repo's current commit rather than the latest

--- a/src/logos_core/module_manager.cpp
+++ b/src/logos_core/module_manager.cpp
@@ -9,11 +9,17 @@
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 #include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <deque>
 #include <mutex>
 #include <cassert>
 #include <cstring>
 #include <optional>
 #include <unordered_set>
+#include <QCoreApplication>
+#include <QObject>
+#include <QPointer>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -25,6 +31,13 @@
 #include "logos_transport_config_json.h"
 #include "token_manager.h"
 #include "instance_persistence.h"
+
+namespace ModuleManager {
+    // Defined later in this TU (in namespace ModuleManager). Forward-declared
+    // here so the loader's onTerminated hook — installed from the anonymous
+    // namespace's loadModuleInternal — can reach the capability crash supervisor.
+    void maybeScheduleCapabilityRestart(const std::string& name);
+}
 
 namespace {
     ModuleRegistry& registryInstance() {
@@ -70,6 +83,46 @@ namespace {
     const std::vector<std::string> kExemptTargets =
         {"capability_module", "core", "core_service"};
 
+    // ── capability_module crash supervisor ──────────────────────────────────
+    //
+    // capability_module is the token authority: every inter-module call needs a
+    // token minted/validated by it. If its subprocess dies (it crashed with a
+    // QtRO SIGSEGV in one incident) and nothing brings it back, ALL token
+    // exchange is dead system-wide until the app restarts. The supervisor below
+    // detects an *unexpected* exit of capability_module and re-provisions it
+    // (respawn + re-teach every loaded module's token). It is deliberately
+    // scoped to capability_module only — ordinary user modules (e.g. a module
+    // with a deterministic panic) must NOT be auto-restarted, or we would just
+    // replay their crash and hide the real bug.
+    bool isAutoRestartTarget(const std::string& name) {
+        return name == "capability_module";
+    }
+
+    // Set during logos_core_cleanup / clear() / terminateAll() so a subprocess
+    // exit that races our own teardown never schedules a respawn into a
+    // tearing-down process tree.
+    std::atomic<bool>& shuttingDown() {
+        static std::atomic<bool> s{false};
+        return s;
+    }
+
+    // NOTE on crash-vs-deliberate-unload: the loader's onTerminated fires ONLY
+    // for spontaneous exits. A deliberate unload/terminate sets the container
+    // entry's `cancelled` flag, and the container gates the onFinished/onError
+    // callback on `!cancelled` (subprocess_container.cpp) — so a user unload of
+    // capability_module never reaches the crash hook below. Combined with the
+    // shuttingDown() latch (set during clear()/terminateAll()/cleanup), that
+    // covers every deliberate teardown without a separate bookkeeping set.
+
+    // Main-thread QObject used to hop the respawn off the loader's background
+    // thread and onto the frontend's Qt event loop, where all QtRO / loadMutex
+    // work is safe. Created on the logos_core_start thread in
+    // initializeCapabilityModule(). Null in a headless test with no event loop.
+    QPointer<QObject>& restartDispatcher() {
+        static QPointer<QObject> d;
+        return d;
+    }
+
     // Built-in default loader, composed from the container + format-loader the
     // build linked in. The concrete implementations are chosen at link time via
     // the contract factory seams (LogosCore::makeContainer / makeFormatLoader);
@@ -109,8 +162,28 @@ namespace {
     // default (LocalSocket). Needed because the single-arg getClient()
     // always uses the global default, which hangs against a tcp-only
     // capability_module that never bound a LocalSocket.
-    LogosAPIClient* capabilityModuleClient() {
+    // The long-lived "core" LogosAPI used to dial capability_module. Held in a
+    // resettable slot so a capability respawn can drop the cached client — its
+    // QRemoteObjectNode is latched onto the DEAD subprocess's socket and would
+    // otherwise 20s-time-out against the fresh one. Only ever touched under
+    // loadMutex() (capabilityModuleClient callers) or on the main thread during
+    // reprovision, so no extra synchronisation is needed.
+    LogosAPI*& coreApiSlot() {
         static LogosAPI* s_coreApi = nullptr;
+        return s_coreApi;
+    }
+
+    // Drop the cached core->capability client so the next capabilityModuleClient()
+    // rebuilds it (fresh consumer + node) against the respawned subprocess.
+    void resetCapabilityModuleClient() {
+        LogosAPI* old = coreApiSlot();
+        coreApiSlot() = nullptr;
+        if (old)
+            old->deleteLater();  // defer: may be reached from a call stack that still unwinds through it
+    }
+
+    LogosAPIClient* capabilityModuleClient() {
+        LogosAPI*& s_coreApi = coreApiSlot();
         if (!s_coreApi)
             s_coreApi = new LogosAPI(std::string("core"));
 
@@ -316,8 +389,15 @@ namespace {
             return false;
         }
 
+        // Fires on the loader's background (asio) thread when the module's
+        // subprocess exits — but ONLY for unexpected exits: a deliberate
+        // terminate() is suppressed upstream by the container's cancelled gate.
+        // Keep the work here cheap and background-safe: markUnloaded (registry
+        // has its own mutex) plus a non-blocking hop to the main thread for the
+        // capability_module respawn. Do NO loadMutex / QtRO work here.
         auto onTerminated = [](const std::string& n) {
             registryInstance().markUnloaded(n);
+            ModuleManager::maybeScheduleCapabilityRestart(n);
         };
 
         LogosCore::LoadedModuleHandle handle;
@@ -507,9 +587,12 @@ namespace ModuleManager {
         return allSucceeded;
     }
 
-    bool initializeCapabilityModule() {
-        std::lock_guard lock(loadMutex());
-
+    // Load (or respawn) capability_module and re-establish ALL of its runtime
+    // state. Assumes loadMutex() is held. One code path for both first boot and
+    // crash recovery, so a respawn is guaranteed to end up in the same state as
+    // a fresh start. Returns false if capability_module is unknown or fails to
+    // load.
+    bool reprovisionCapabilityLocked() {
         if (!registryInstance().isKnown("capability_module"))
             return false;
 
@@ -518,14 +601,122 @@ namespace ModuleManager {
             return false;
         }
 
-        // Register restrictions before any other module can call out: explicit
-        // entries, then derived for anything already loaded (usually nothing —
-        // only the exempt capability_module is up here).
+        // A respawned capability_module is a brand-new subprocess on the same
+        // registry URL, so any cached core->capability client is latched onto
+        // the dead socket. Drop it before we RPC to the fresh one.
+        resetCapabilityModuleClient();
+
+        // Register restrictions: explicit entries, then derived for anything
+        // already loaded (on first boot only capability_module is up, so the
+        // loop is a no-op; on a respawn every previously-loaded module is here).
         pushAccessRestrictionsToCapabilityModule();
         for (const auto& loaded : registryInstance().loadedModuleNames())
             pushDerivedRestrictionForTarget(loaded);
 
+        // Re-teach every already-loaded module's token. A freshly respawned
+        // capability_module starts with an EMPTY in-memory token store, so
+        // without this the outage would survive the restart: every peer's
+        // requestModule handshake keeps failing. loadModuleInternal above
+        // already taught capability its own token; teach the rest here. No-op on
+        // first boot. TokenManager is the durable source of truth (tokens are
+        // saved there at each module's load), never capability's wiped map.
+        for (const auto& name : registryInstance().loadedModuleNames()) {
+            if (name == "capability_module")
+                continue;
+            notifyCapabilityModule(name, TokenManager::instance().getToken(name));
+        }
+
         return true;
+    }
+
+    bool initializeCapabilityModule() {
+        // A fresh start clears the shutdown latch so a prior clear()/cleanup in
+        // the same process (tests, daemon restart) doesn't suppress recovery.
+        shuttingDown().store(false);
+
+        // Create the main-thread dispatcher used to marshal a crash-triggered
+        // respawn off the loader's background thread. logos_core_start (our
+        // caller) runs on the frontend's Qt thread, so this QObject gets the
+        // right thread affinity. Harmless when there is no event loop (headless
+        // tests): the queued respawn simply never runs.
+        if (!restartDispatcher())
+            restartDispatcher() = new QObject();
+
+        std::lock_guard lock(loadMutex());
+        return reprovisionCapabilityLocked();
+    }
+
+    // Sliding-window crash-loop guard. Touched only on the main thread inside
+    // performCapabilityRestart, so no locking needed.
+    std::deque<std::chrono::steady_clock::time_point>& capabilityRestartHistory() {
+        static std::deque<std::chrono::steady_clock::time_point> h;
+        return h;
+    }
+
+    // Runs on the main thread (posted from the crash hook). Respawns
+    // capability_module, bounded by a crash-loop circuit breaker so a
+    // deterministically-crashing capability can't fork-bomb.
+    void performCapabilityRestart() {
+        using namespace std::chrono;
+        if (shuttingDown().load())
+            return;
+
+        constexpr int kMaxRestarts = 3;
+        constexpr auto kWindow = seconds(60);
+
+        auto& history = capabilityRestartHistory();
+        const auto now = steady_clock::now();
+        while (!history.empty() && now - history.front() > kWindow)
+            history.pop_front();
+        if (static_cast<int>(history.size()) >= kMaxRestarts) {
+            spdlog::critical(
+                "capability_module crashed {} times within {}s — auto-restart "
+                "DISABLED, token exchange is DEGRADED; restart the application",
+                kMaxRestarts, duration_cast<seconds>(kWindow).count());
+            return;
+        }
+        history.push_back(now);
+
+        std::lock_guard lock(loadMutex());
+        // A concurrent explicit (re)load may have already brought it back.
+        if (registryInstance().isLoaded("capability_module"))
+            return;
+
+        spdlog::warn("capability_module exited unexpectedly — auto-restarting "
+                     "(attempt {} of {} within {}s)",
+                     history.size(), kMaxRestarts,
+                     duration_cast<seconds>(kWindow).count());
+        if (reprovisionCapabilityLocked())
+            spdlog::info("capability_module auto-restart succeeded; token "
+                         "exchange restored");
+        else
+            spdlog::error("capability_module auto-restart failed");
+    }
+
+    // Runs on the loader's background (asio) thread from onTerminated. Decides
+    // whether an exit warrants a respawn and, if so, hops it to the main thread.
+    // Kept cheap and non-blocking: NO loadMutex, NO QtRO here.
+    void maybeScheduleCapabilityRestart(const std::string& name) {
+        if (!isAutoRestartTarget(name))
+            return;
+        if (shuttingDown().load())
+            return;
+        // Deliberate unloads never reach here (the container's cancelled gate
+        // suppresses onTerminated for them), so any exit we see is a crash /
+        // unexpected self-exit worth recovering from.
+
+        QObject* dispatcher = restartDispatcher();
+        if (!dispatcher || !QCoreApplication::instance()) {
+            spdlog::error("capability_module exited but no event loop is "
+                          "available to auto-restart it — token exchange is "
+                          "DEGRADED until the application restarts");
+            return;
+        }
+
+        // Non-blocking hop to the main thread. Must NOT block: this runs on the
+        // shared loader io thread that also pumps every module's stdout.
+        QMetaObject::invokeMethod(dispatcher, []() { performCapabilityRestart(); },
+                                  Qt::QueuedConnection);
     }
 
     bool unloadModule(const char* moduleName) {
@@ -599,12 +790,16 @@ namespace ModuleManager {
     }
 
     void terminateAll() {
+        // Suppress capability auto-restart: the terminations below are ours, not
+        // crashes. (initializeCapabilityModule clears the latch on next boot.)
+        shuttingDown().store(true);
         std::lock_guard lock(loadMutex());
         loaderRegistry().terminateAll();
         registryInstance().clearLoaded();
     }
 
     void clear() {
+        shuttingDown().store(true);  // see terminateAll(): don't respawn during our own teardown
         std::lock_guard lock(loadMutex());
         loaderRegistry().terminateAll();
         registryInstance().clear();

--- a/src/logos_core/module_manager.cpp
+++ b/src/logos_core/module_manager.cpp
@@ -596,15 +596,19 @@ namespace ModuleManager {
         if (!registryInstance().isKnown("capability_module"))
             return false;
 
+        // Drop any cached core->capability client BEFORE (re)loading. On a
+        // respawn it is latched onto the dead subprocess's socket, and
+        // loadModuleInternal itself RPCs to capability_module
+        // (notifyCapabilityModule for its own token, via capabilityModuleClient),
+        // so a stale client would make that call hang on the dead socket. The
+        // next capabilityModuleClient() rebuilds it against the fresh subprocess.
+        // No-op at first boot (the client doesn't exist yet).
+        resetCapabilityModuleClient();
+
         if (!loadModuleInternal("capability_module")) {
             spdlog::warn("Failed to load capability module");
             return false;
         }
-
-        // A respawned capability_module is a brand-new subprocess on the same
-        // registry URL, so any cached core->capability client is latched onto
-        // the dead socket. Drop it before we RPC to the fresh one.
-        resetCapabilityModuleClient();
 
         // Register restrictions: explicit entries, then derived for anything
         // already loaded (on first boot only capability_module is up, so the
@@ -664,6 +668,13 @@ namespace ModuleManager {
         constexpr int kMaxRestarts = 3;
         constexpr auto kWindow = seconds(60);
 
+        std::lock_guard lock(loadMutex());
+        // A concurrent explicit (re)load may have already brought it back — check
+        // BEFORE recording an attempt so a no-op restart doesn't consume one of
+        // the limited attempts and trip the circuit breaker early.
+        if (registryInstance().isLoaded("capability_module"))
+            return;
+
         auto& history = capabilityRestartHistory();
         const auto now = steady_clock::now();
         while (!history.empty() && now - history.front() > kWindow)
@@ -676,11 +687,6 @@ namespace ModuleManager {
             return;
         }
         history.push_back(now);
-
-        std::lock_guard lock(loadMutex());
-        // A concurrent explicit (re)load may have already brought it back.
-        if (registryInstance().isLoaded("capability_module"))
-            return;
 
         spdlog::warn("capability_module exited unexpectedly — auto-restarting "
                      "(attempt {} of {} within {}s)",


### PR DESCRIPTION
## What
A crash supervisor for `capability_module` — the token authority every inter-module call is brokered through. If its subprocess dies unexpectedly and nothing restarts it, all token exchange is dead system-wide until the app restarts (observed in the field after a mid-session module crash).

The loader's `onTerminated` hook (fires only for spontaneous exits — deliberate unloads are suppressed by the container's `cancelled` gate) does cheap work on its background thread, then marshals a respawn onto the main thread. `performCapabilityRestart` reprovisions capability under `loadMutex`: reload → **re-teach every loaded module's token** (a fresh capability starts with an empty store) → re-push restrictions.

`initializeCapabilityModule` is refactored into a shared `reprovisionCapabilityLocked`, so first boot and recovery take one path.

**Guards:** 3-in-60s crash-loop circuit breaker (log-and-stop, never fork-bomb), a `shuttingDown` latch so `clear()`/`terminateAll()` never respawn, `isLoaded` idempotency, and a headless fallback when there's no event loop.

## Test
- liblogos unit suite passes.
- **End-to-end**: in a running logoscore daemon, `kill -9` on capability's subprocess → supervisor logs `auto-restarting (1 of 3)` → `auto-restart succeeded; token exchange restored`; capability returns `loaded` with a fresh subprocess.

## Note
Independent of the capability-crash *prevention* work (the Qt-free `concurrency:"multi"` rewrite across protocol/cpp-sdk/qt-sdk/capability-module) — this is the availability net for any future capability crash and can merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)