### PR TITLE
chore: actually pin logos-protocol to 362b03f (follow-up to #166)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12183,11 +12183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784686752,
-        "narHash": "sha256-YfIUX0xYtvp7FrvYJtBDDZNzQsCPihWEZ6GxvKwVifA=",
+        "lastModified": 1785261709,
+        "narHash": "sha256-dcI6zmGy5+99MB9TaN7KGJkbvDWV8WT+B/8b5UPLjkE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "6401e30ae1cfabac77285ee8e7a82c2cef3858f1",
+        "rev": "362b03fb1ec25b35ed5d630670f5fd2bd899b196",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follow-up to #166, which did not land the pin it claimed.

#166's diff contains `362b03f`, but on master the ROOT `logos-protocol` input
resolves to node `logos-protocol_10` at `6401e30` — the pre-fix rev — while
`362b03f` sits in a transitive slot (`logos-protocol_7`). `logos-cpp-sdk` landed
correctly.

The cause is that the branch's `flake.lock` had been re-locked with a different
node numbering than master's, so merging it as a 12-line textual diff patched
lines that no longer meant what they did on the branch. Re-running
`nix flake update logos-protocol` on master still moves the pin, which is the
proof that master was not actually on it:

```
6401e30 -> 362b03f
```

This commit is that re-run: 3 lines, `logos-protocol` only (cpp-sdk is already
correct). Tests pass.

### Why it matters

`logos-liblogos` is the module host, and consumers deliberately do NOT `follows`
its protocol — logoscore-cli's flake says so in a comment: *"liblogos's own SDK
pin still drives transitive deps."* So while liblogos is pinned pre-fix, every
consumer that links it gets the pre-fix protocol for the host path, no matter
what they pin themselves. That is what this unblocks.

Worth a look at whether other recently-merged lock bumps landed the same way —
qt-sdk#18 is correct, so this is not systematic, but it is silent when it happens.
