### PR TITLE
chore: bump logos-protocol to the uint64 fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12183,11 +12183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785261709,
-        "narHash": "sha256-dcI6zmGy5+99MB9TaN7KGJkbvDWV8WT+B/8b5UPLjkE=",
+        "lastModified": 1785295592,
+        "narHash": "sha256-CQ7QNiBaEf/s+om7pK9NtmYnZ4oDWHgPwX3muZ5uYdE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "362b03fb1ec25b35ed5d630670f5fd2bd899b196",
+        "rev": "8b8a358c8bfdf92e54c5164fd460c4ab31e2f400",
         "type": "github"
       },
       "original": {
@@ -12979,11 +12979,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784687933,
-        "narHash": "sha256-GECc9sqeFWYQdya1/QDH0NThHRidy6MRIBAIaO7AAyE=",
+        "lastModified": 1785272352,
+        "narHash": "sha256-Wp6Gmsk+GlpwrR1giqPvpkJqBaBsEKJ+pkmbziTD6kQ=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "2ec59459a3a6ad541eab1b3b10861ae76575e488",
+        "rev": "af767b7ea7e083d7a67c712826fb71926e5393e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-protocol` to **8b8a358** (logos-co/logos-protocol#30), which fixes two places where a uint64 above int64max quietly stopped being itself.

**The event bridge.** `setEventListenerStdBridge` converted with `QJsonDocument::fromJson` + `QJsonValue::toVariant` instead of `logos::nlohmannArgsToQVariantList` — the helper the method path already used. So `uintEvent(2^64-1)` arrived as `1.8446744073709552e+19` while `echoUint(2^64-1)` was exact: same value, same process, one hop later. The same bridge also failed to decode canonical `{"_bytes": ...}` into a `QByteArray`.

**The plain wire.** `RpcValue` had no unsigned alternative, so the same value wrapped to `-1` — silently, and independently in each direction. Not a wire-format limit: both codecs carry uint64 natively and the envelope's own `id` field already crossed as `uint64_t`.

Retires **M6** from the LIDL conformance matrix (logos-co/logos-test-modules#29, merged).

Lock-only change. Verified: 226/226 in protocol, and end-to-end with a negative control — new 64-bit boundary cases fail on the previous pin over tcp with exactly `-9223372036854775808`, `-1` and `1.8446744073709552e+19`, and all 68 pass with this one on local, tcp and tcp_ssl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)