### PR TITLE
chore: bump logos-protocol to the signedness + sentinel fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12183,11 +12183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785295592,
-        "narHash": "sha256-CQ7QNiBaEf/s+om7pK9NtmYnZ4oDWHgPwX3muZ5uYdE=",
+        "lastModified": 1785336618,
+        "narHash": "sha256-s+3ZB2cVUJe1+dEZzpQlD46w2xZWXu5L4K1v15HNhBk=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "8b8a358c8bfdf92e54c5164fd460c4ab31e2f400",
+        "rev": "c0df466172497741dfaa25d2e74a98947df60ada",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-protocol` to **c0df466** (logos-co/logos-protocol#31), which lands two independent fixes:

**Integer signedness and range in `Codec<T>`.** A negative could wrap into an unsigned (`-1` → `18446744073709551615`) and a wide value could truncate, both silently, because the codec checked only that the JSON number was integral.

**A shape check on the pending-call sentinel.** All four detection sites tested `m.contains(pendingCallKey())` and nothing else, so any user map carrying that key was taken for a deferred call — the consumer then waited out a nested event loop and the call hung for ~20 seconds. Relevant here because liblogos is the host that forwards those calls.

Lock-only. `nix build .#checks.<sys>.tests` green on liblogos' own lock; root protocol verified at `c0df466`.

Note if you test this through the workspace instead: `ws test logos-liblogos --local logos-liblogos` currently fails with `no member named 'getRawMetadataJson' in 'ModuleLib::LogosModule'`. That is not this change and not liblogos — the workspace pins `logos-module 7583396` and forces it onto liblogos via `inputs.logos-module.follows`, which is older than liblogos' own lock requires. On its own lock it builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)