### PR TITLE
chore: bump logos-protocol to the whole-valued-float fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1573,11 +1573,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785270289,
-        "narHash": "sha256-kig2GkKDY7S50tffIf/HhOAldvVGzXP0wheCVKPFeeM=",
+        "lastModified": 1785353260,
+        "narHash": "sha256-z8NPSvBNM7AxcNTqTc/DdvFAXLeHiZ12enSgjh3qU40=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "3d322bd3159075443f4976ebb35040a70f7ff3df",
+        "rev": "5f63af681ac4805d059332b63e6191c4a8e2820d",
         "type": "github"
       },
       "original": {
@@ -12183,11 +12183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785336618,
-        "narHash": "sha256-s+3ZB2cVUJe1+dEZzpQlD46w2xZWXu5L4K1v15HNhBk=",
+        "lastModified": 1785352565,
+        "narHash": "sha256-i5ynBtNk6Qe+YSHsa+O8DjnLpHXDVqyLGPxBAImipD8=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "c0df466172497741dfaa25d2e74a98947df60ada",
+        "rev": "4ee85b26a65e331821823f6435135c088a1bf447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Upstream half of unbreaking `logos-logoscore-cli` master, which has been red on doc-tests since it picked up protocol `c0df466` (`call test_basic_module addInts 40 2` fails).

| input | | |
|---|---|---|
| `logos-protocol` | 4ee85b2 | logos-co/logos-protocol#32 (whole-valued floats) + #33 + #34 |
| `logos-cpp-sdk` | 5f63af6 | |

liblogos was pinning **c0df466** — #31's signedness check *without* #32's follow-up. That is the version which rejected `3.0` as well as `3.7`, and it is the same defect that failed four `test_basic_module_cpp` cases when it reached test-modules.

**Why this repo rather than the consumer:** the daemon embeds liblogos, so liblogos' protocol pin is what a `logoscore call` actually executes — independent of what logoscore-cli pins directly. And liblogos declares no `follows` for protocol, so bumping the consumer alone leaves this copy behind. I confirmed that by inspecting a bumped logoscore-cli lock: root `logos-protocol` moved to `4ee85b2` while `liblogos/logos-protocol` stayed at `c0df466`.

`nix build .#checks.<sys>.tests` green on liblogos' own lock; root protocol verified at `4ee85b2`.

Once this merges, logoscore-cli needs a matching bump to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)