### PR TITLE
chore: bump logos-protocol to the off-strand socket close fixes (#38, #39)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12183,11 +12183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785352565,
-        "narHash": "sha256-i5ynBtNk6Qe+YSHsa+O8DjnLpHXDVqyLGPxBAImipD8=",
+        "lastModified": 1785523697,
+        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "4ee85b26a65e331821823f6435135c088a1bf447",
+        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-protocol` **4ee85b26 → 3a31c91d** (master). One node, three lines of `flake.lock`.

liblogos is first in a four-repo propagation chain — see [Merge order](#merge-order) at the bottom.

## Why this pin matters here specifically

`logos_protocol` is a **static** archive (`add_library(logos_protocol STATIC …)`). Every consumer links its own copy of the transport code into its own binary, so the plain-transport implementation running inside `liblogos_core.dylib` *is* whatever this pin says — there is no shared library for a downstream bump to fix later.

That is also why liblogos was the blocker for the rest of the chain: liblogos is linked into logos-logoscore-cli, basecamp and the module runtime, and a consumer that bumped only its own root pin still got liblogos's older protocol in the same process image.

## What the fixes are

Both are the same race on two different asio objects — a close issued off the strand that serializes every other access.

**[#38](https://github.com/logos-co/logos-protocol/pull/38) — the connection socket.** `RpcConnection<Stream>::fail()` closed the socket on whatever thread called it, while `start()`, `writeFrame()`, `doRead()` and `doWrite()` were all serialized on `m_strand`. A strand serializes *handlers*, not a raw call made from outside it, and asio sockets are documented "Shared objects: Unsafe". Consumer teardown (`~RpcClient → ~PlainTransportConnection → stop() → fail()`) therefore ran `close() → cleanup_descriptor_data()`, nulling `impl.reactor_data_`, while the io worker was inside `reactive_socket_service_base::start_op()` for a write that had just been posted — `start_op`'s `descriptor_data` is a reference to that member, so the null check passes before the store lands and the `shutdown_` read after it dereferences null. SIGSEGV at `+0x98` on the `IoContextPool` thread.

**[#39](https://github.com/logos-co/logos-protocol/pull/39) — the acceptor.** `RpcServerTcp::stop()` / `RpcServerSsl::stop()` closed `m_acceptor` on the host thread (via `~PlainTransportHost`) while `doAccept()` re-armed `async_accept` from inside its own completion handler on the io worker. Same failure mode, same `+0x98`. It was left out of #38 because every backtrace captured in the wild was a write initiation, never an accept.

Both now hand the close to a strand via `dispatch()` — inline when already on the strand, queued and non-blocking otherwise.

**This is a false negative, not a lost result.** The RPC completes and prints the correct answer, *then* teardown crashes. Anything that checks the exit code before parsing stdout reports a healthy call as failed. Measured upstream at ~0.45% of calls over `tcp` and `tcp_ssl`, 0 over `local`/QtRO.

Also swept up between the two pins, both additive: [#35](https://github.com/logos-co/logos-protocol/pull/35) `jsonToLogosResult` and [#37](https://github.com/logos-co/logos-protocol/pull/37) `Codec<std::optional<T>>`.

## Verification (aarch64-darwin)

**Unit tests — `nix build .#checks.<sys>.tests`, which is what CI runs:**

| | tests | suites | failures | errors | disabled |
|---|---|---|---|---|---|
| `origin/master` (4ee85b26) | 181 | 16 | 0 | 0 | 0 |
| this branch (3a31c91d) | 181 | 16 | 0 | 0 | 0 |

Identical — no regression, and no new coverage either. Protocol's own regression tests for these races (`test_rpc_connection_teardown.cpp`, `RpcServerTeardownTest`) live in logos-protocol and run there.

**The fix is in the artifact, not just the lock.** Since the archive is static, a green lock file proves nothing on its own — so I diffed the symbol tables of `lib/liblogos_core.dylib` from `nix build .#default` on both revisions. The new private methods introduced by the two fixes appear only on this branch:

| symbol | `origin/master` | this branch |
|---|---|---|
| `RpcConnection::closeStreamOnStrand` (#38) | 0 | 16 |
| `RpcServerTcp/Ssl::closeAcceptorOnStrand` (#39) | 0 | 10 |

`nix build .#default` and `.#logos-liblogos-modules` both succeed.

## Every protocol node in the closure

The trap this chain already hit once is that bumping the *root* pin is not sufficient — a sibling input can bring its own older protocol into the same process. So I resolved every `logos-protocol` edge in `flake.lock` (a `follows` entry is a **path array resolved from the root node**, not a node name; a resolver that reads the first element as a node name reports the wrong revisions).

**The strand that feeds `liblogos_core` now agrees at 3a31c91d — all four edges:**

| edge | resolves to |
|---|---|
| `logos-protocol` (root) | 3a31c91d |
| `logos-cpp-sdk.logos-protocol` | 3a31c91d |
| `logos-qt-sdk.logos-protocol` | 3a31c91d |
| `default-module-loader.logos-protocol` | 3a31c91d |

Those three non-root edges are already `follows` declarations in `flake.nix`, so this one-node bump moved all four. Confirmed by resolution, not by grepping revisions.

`default-container` (logos-container-subprocess), `logos-container`, `logos-module-loader`, `logos-module` and `logos-package-manager` have **no** `logos-protocol` input at all, so they cannot contribute a stale copy.

## Known residue: logos-capability-module (not fixed here — on purpose)

One sibling still brings its own protocol, and I want it visible rather than buried:

```
logos-capability-module → logos-module-builder (4717b9af) → logos-protocol 6401e30a
```

`logos-capability-module` has exactly one input (`logos-module-builder`), and module-builder already declares `logos-cpp-sdk.inputs.logos-protocol.follows` / `logos-qt-sdk.inputs.logos-protocol.follows`, so all three of its protocol edges resolve to that single stale node.

**It is real, not just lock noise.** liblogos bundles `capability_module` into `.#logos-liblogos-modules` and uses it as `TEST_PLUGIN`, so it is loaded into the same process. `capability_module_plugin.dylib` has no `liblogos_protocol` in `otool -L` and 855 `logos::plain` symbols in its own text — it statically embeds a full protocol copy, including 380 `RpcConnection` and 108 `RpcServer` symbols, with `closeStreamOnStrand` absent. That copy is definitively pre-fix. The revisions also straddle wire-affecting codec changes (#31 signedness/sentinel, #32 whole-valued float, #33 bstr path).

**Why I did not fix it here.** The fix belongs in `logos-capability-module` — bumping its `logos-module-builder` — not in a three-level-deep nested `follows` in liblogos's flake. Note that this residue is *not* specific to liblogos: logos-logoscore-cli master carries the identical `logos-liblogos.logos-capability-module.logos-module-builder.logos-protocol → 6401e30a` edge even with the `logos-liblogos.inputs.logos-protocol.follows` fix from logoscore-cli#81 in place.

**If you want it closed sooner**, I measured that the workaround works — this line alone moves all three of capability-module's protocol edges to 3a31c91d and `nix build .#logos-liblogos-modules` succeeds with it (cpp-sdk, qt-sdk and capability_module all rebuild cleanly):

```nix
logos-capability-module.inputs.logos-module-builder.inputs.logos-protocol.follows = "logos-protocol";
```

I left it out because it forces a from-source rebuild of capability_module in every downstream consumer (no binary-cache hit for the standard combination), and it resolves itself for free once module-builder lands at the end of this chain and capability-module is re-locked onto it. Happy to add it if you would rather not wait.

The remaining `logos-protocol` nodes in the lock all sit under `logos-capability-module.logos-module-builder.logos-standalone-app.…` and `.logos-test-framework.…` — module-builder's own test/host-shell inputs. They do not contribute to any artifact liblogos builds or loads.

## Merge order

This is repo 1 of 4. Merge strictly in dependency order, re-locking each against the previous:

1. **logos-liblogos** ← this PR
2. logos-cpp-sdk (currently 72754ab9)
3. logos-qt-sdk (currently ec43a0b4 — pins both protocol and cpp-sdk)
4. logos-module-builder (currently 72754ab9 — follows protocol, pins cpp-sdk/qt-sdk/rust-sdk)

`logos-rust-sdk` needs no bump: verified it has **no** `logos-protocol` input (root inputs are `logos-lidl`, `logos-logoscore-cli`, `logos-module-builder`, `logos-nix`, `nixpkgs`); it reaches protocol through module-builder and moves with step 4.

Separately, logos-logoscore-cli's own root protocol pin is currently **4db061a** (#38 only) and will want a follow-up to pick up #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
