### PR TITLE
Bump the module loader for the host logging fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784686952,
-        "narHash": "sha256-0QVyGF6cpDz8RLozz1qypS7a/k0w6yBs9zGlkZMxZe4=",
+        "lastModified": 1785971700,
+        "narHash": "sha256-Nj4wv/PyvY9Kyuv5rsop/fQ5utm1X52zWiXPeDXSJEA=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "bc46dbfc5e2fbbe259fbd30982bf563a772b918b",
+        "rev": "811d83407822091817719d8e46de26e548e23b19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
[logos-module-loader-qt#5](https://github.com/logos-co/logos-module-loader-qt/pull/5) makes `logos_host` install its own Qt message handler, so a module's diagnostics reach the daemon that spawned it instead of being diverted to journald by Qt's default backend.

**liblogos is the carrier.** Nothing downstream — logosctl, logoscore, Basecamp — sees that fix until this pin moves.

## Why the host needed fixing

`logos-container-subprocess` gives each child dedicated pipes rather than the daemon's fds. `logos_host` was the only process in the tree installing no Qt message handler, so Qt picked a backend, and a Qt built with journald support sends `qDebug`/`qInfo`/`qWarning` there once stderr is not a terminal — always true for a spawned host. Not the systemd path either: `JOURNAL_STREAM` was unset and it still diverted.

## Measured

End to end on Linux, same install workload, with both halves in place (this loader plus [logos-logoscore-cli#83](https://github.com/logos-co/logos-logoscore-cli/pull/83), which fixes a `-v` that never reached the daemon and raises spdlog's level so the forwarded records survive the filter):

| | log lines | module lines | journald |
|---|---|---|---|
| before | 200 | 1 | **59** |
| after | 251 | **46** | **0** |

Both halves are required — either alone leaves the count at 1.

## Scope

Single-input bump: `default-module-loader` `bc46dbf` → `811d834`. Nothing else in the lock moved (verified by decoding it, not by reading the diff). `nix flake check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)