### PR TITLE
chore: pin logos-protocol 0f26ffd, and move CI off Nix 2.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v27
+      # v27 ships Nix 2.22, which is old enough to mis-handle several flake
+      # locking features (notably nested `a.inputs.b.inputs.c.follows` and the
+      # precedence of an --override-input'd input's own lock). v31 ships 2.35,
+      # matching what logos-standalone-app already uses.
+      uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes

--- a/flake.lock
+++ b/flake.lock
@@ -12183,11 +12183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785523697,
-        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
+        "lastModified": 1786030193,
+        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
+        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Two changes:

1. `flake.lock`: root `logos-protocol` `3a31c91d1` (Jul 31) → `0f26ffdeef` (Aug 6, current master). A clean 3-line lock diff; no transitive churn.
2. `.github/workflows/ci.yml`: `cachix/install-nix-action@v27` → `@v31`.

## Why — this is the proper fix for the split-protocol problem, not a `follows` workaround

`logos-protocol` is **statically linked** into liblogos: `nix path-info -r` on the built `logos-liblogos-tests` output shows **zero** protocol store paths, and `liblogos_core.dylib` alone carries **299 weak external definitions**. On macOS, when two images built against different protocol revisions end up in one process, dyld coalesces those weak definitions and one image's protocol code silently binds to the other's.

That is not theoretical across this particular span: protocol #41 changed

```
logos::plain::PlainLogosObject::awaitCompletion(QString const&, int)
→ logos::plain::PlainLogosObject::awaitCompletion(QString const&, int, QString const&, logos::CallError*)
```

The signature is private to the plain transport, so it is source-compatible for every consumer — which is exactly why the mismatch never shows up at build time.

The short-term workaround was a set of `follows` overrides pushed down from `logos-module-builder`. That spelling needs a **nested** `a.inputs.b.inputs.c.follows`, which Nix 2.22.1 cannot evaluate. Having each repo pin the current protocol itself removes the need for any override. **No `follows` line is added or changed here** — `flake.nix` is untouched.

## Span being crossed

Exactly two commits, `3a31c91..0f26ffd`:

- `d0523c1` — fix(lp): `lp_invoke_async` can finally report a failure (protocol #40)
- `0f26ffd` — fix(protocol): report the failures that happen AFTER acquire — on both twins, without moving the ABI (protocol #41)

17 files, +4135/−70, of which **+3140 is new test code** under `tests/protocol/`. The consumer-visible header changes in this range are purely additive.

## Why the CI installer bump rides along

It is hygiene, **not** a requirement for the pin — one-level `a.inputs.b.follows` (which is all this repo uses) evaluates fine on 2.22.1, and this PR is verified green on it (below).

But `install-nix-action@v27` installs **Nix 2.22.1** (`install-nix.sh` line 96 → `nix-2.22.1/install`), which mis-handles several flake locking features: nested `follows`, and the precedence of an `--override-input`'d input's own lock. `@v31` installs **2.35.1** (`install-nix.sh` line 105 → `nix_version=2.35.1`). `logos-standalone-app` already moved its CI to `@v31` for the second of those reasons and carries an inline comment saying so; this matches it.

The `doctests.yml` job is unaffected — it already uses `DeterminateSystems/nix-installer-action@main`.

## Verified (aarch64-darwin, by running — not inferred)

**From-scratch re-lock.** `flake.lock` deleted, then re-locked from nothing. Succeeds and lands back on `0f26ffd` under **all three** Nix versions, and a second `nix flake lock` is a no-op (lock is stable):

| Nix | source | fresh re-lock | root protocol after |
|---|---|---|---|
| 2.22.1 | what `@v27` installs (CI **today**) | ok | `0f26ffd` |
| 2.32.4 | local | ok | `0f26ffd` |
| 2.35.1 | what `@v31` installs (CI **after this PR**) | ok | `0f26ffd` |

Both 2.22.1 and 2.35.1 are the exact upstream builds (`nix build github:NixOS/nix/2.22.1` / `/2.35.1`), not nixpkgs approximations.

**All three Nix versions evaluate the committed lock to the byte-identical derivation** `/nix/store/a1v4ihn5yv22kw73k5v979jpzwwi3qlx-logos-liblogos-tests-0.1.0.drv` — so what was built and tested locally is what CI will build, on either installer.

**Build + tests** — the two steps `ci.yml` actually runs:

```
$ nix build .#logos-liblogos-tests      # exit 0
$ ./result/bin/logos_core_tests         # exit 0
[==========] 181 tests from 16 test suites ran. (633 ms total)
[  PASSED  ] 176 tests.
[  SKIPPED ] 5 tests
```

**Baseline comparison.** The same build+run at the pre-bump parent `f63cda3` gives **181 / 176 passed / the same 5 skipped**. The bump changes nothing. The 5 skips are the pre-existing environment skips (`No real test module available. Set TEST_PLUGIN env var`), not protocol-related — `ci.yml` does not set `TEST_PLUGIN`.

**The full suite with no skips at all.** `nix build .#checks.aarch64-darwin.tests` does set it, to a real `capability_module_plugin.dylib`, and passes **181 / 181, 0 failures, 0 skipped** (`test-results.xml`: `tests=181 failures=0 errors=0`). Worth calling out because that plugin is itself built against protocol `6401e30a` via its own `logos-module-builder` (see residual below) — so this exercises loading an older-protocol plugin into a `0f26ffd` host, and it is clean.

**The pin actually reaches the artifact.** The 0f26ffd flake source `/nix/store/fpnlgs05vyxvp4y74rf05dxcj9rl55lb-source` is an input of the `logos-protocol-lib-0.2.0.drv` in the tests build, and the resulting `liblogos_protocol.a` exports the **new** 4-argument `awaitCompletion`.

Also built green: `.#default`, `.#portable`, `.#logos-liblogos-modules`.

**CI on this PR** (the real thing, not a local approximation):

| job | result |
|---|---|
| `build-and-test` (ubuntu, **Nix 2.35.1** via the new `@v31`) | **pass**, 2m8s — log confirms `downloading Nix 2.35.1`, then `181 tests ... 176 PASSED` |
| `liblogos doc-tests (ubuntu-latest)` | **pass**, 11m1s |
| `liblogos doc-tests (macos-latest)` | **pass**, 13m22s |
| `Publish report to GitHub Pages` | **pass** |

All checks green.


## Known residual this PR does not fix

After this bump the **only** protocol revision reachable from this repo's own inputs is `0f26ffd`. Every other protocol node left in the lock is reached exclusively through `logos-capability-module` (`390486e22`, Jul 20), which pulls `6401e30a` via its own `logos-module-builder` (`4717b9af3`):

```
root.logos-capability-module.logos-module-builder.logos-protocol → 6401e30a
```

No pin or `follows` inside this repo can move that — it needs its own capability-module → module-builder → protocol chain. Flagging it because liblogos ships that plugin in `.#logos-liblogos-modules` and sets it as `TEST_PLUGIN` in `checks.tests`.

## Scope

Part of a per-repo sweep bringing every repo in the chain onto protocol `0f26ffd`. Independent of the other repos' bumps — this one does not need to land in any particular order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
